### PR TITLE
Fix AliasRefresh Button not appearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.3 - Unreleased
+
+* Fix cookies expiring on browser close #206
+* Fix refresh aliases button not appearing #194
+
 # 0.2.2 - 2019-01-15
 
 * Fix security vulnerability - /api/capcodes route unsecured and leaking confidential info when hideCapcode and secMode both disabled

--- a/server/public/javascripts/admin/admin.main.js
+++ b/server/public/javascripts/admin/admin.main.js
@@ -35,7 +35,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
       });
       Api.Settings.get(null, function(results) {
         if (results) {
-          if (results.database && results.database.aliasRefreshRequired == 1) {
+          if (results.settings.database && results.settings.database.aliasRefreshRequired == 1) {
             $scope.aliasRefreshRequired = 1;
             $scope.alertMessage.text = 'Alias refresh required!';
             $scope.alertMessage.type = 'alert-warning';


### PR DESCRIPTION
# Description

Fixes Alias Refresh Button not appearing on Alias Index page when required

Fixes # (issue)

Fixes https://github.com/pagermon/pagermon/issues/194

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Confirmed button is now appearing correctly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



