### PR TITLE
Timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Fix 404 error when trailing slash added to hostname in client config #223
 * Patch Total.js CVE #232
 * Message Repeat Plugin #222
+* Parse timestamps in messages #72
+* Compatibility with multimon timestamp option #57
 
 # 0.2.3 - 2019-02-05
 

--- a/client/README.md
+++ b/client/README.md
@@ -25,6 +25,8 @@ Edit config/config.json to suit your environment. Identifier should be a small s
 
 Some environments send additional information via the "Function Code" in the pager message. Change `sendFunctionCode` to `true` to send this appended to the end of the address of each message. E.g. `POCSAG512: Address: 1000022  Function: 3  Alpha: test` would land on the server with an address of `10000223`.
 
+Some environments prepend pager messages with a timestamp - by default reader.js will trim these from the message and use them as the timestamp for the message. If you do not wish for this to happen, set `useTimestamp` to `false`. Only a limited type of timestamps are currently supported - if you wish to add a time format, submit an issue with some example messages.
+
 Check the samples dir for example usage.
 
 ## Contributing

--- a/client/config/default.json
+++ b/client/config/default.json
@@ -2,5 +2,6 @@
   "apikey": "changeme",
   "hostname": "http://127.0.0.1:3000",
   "identifier": "TEST",
-  "sendFunctionCode": false
+  "sendFunctionCode": false,
+  "useTimestamp": true
 }

--- a/client/reader.js
+++ b/client/reader.js
@@ -68,7 +68,7 @@ rl.on('line', (line) => {
   var trimMessage;
   // TODO: pad address with zeros for better address matching
 //  if (line.indexOf('POCSAG512: Address:') > -1) {	
-  if (/^POCSAG(\d+): Address: /.test(line) ) {
+  if (/POCSAG(\d+): Address: /.test(line) ) {
     address = line.match(/POCSAG(\d+): Address:(.*?)Function/)[2].trim();
     if (sendFunctionCode) {
       address += line.match(/POCSAG(\d+): Address:(.*?)Function: (\d)/)[3];

--- a/client/reader.js
+++ b/client/reader.js
@@ -30,6 +30,7 @@ var hostname = nconf.get('hostname');
 var apikey = nconf.get('apikey');
 var identifier = nconf.get('identifier');
 var sendFunctionCode = nconf.get('sendFunctionCode') || false;
+var useTimestamp = nconf.get('useTimestamp') || true;
 
 //Check if hostname is in a valid format - currently only removes trailing slash - possibly expand to validate the whole URI? 
 if(hostname.substr(-1) === '/') {
@@ -62,6 +63,7 @@ var frag = {};
 rl.on('line', (line) => {
   //console.log(`Received: ${line.trim()}`);
   var time = moment().format("YYYY-MM-DD HH:mm:ss");
+  var timeString = '';
   var datetime = moment().unix();
   var address;
   var message;
@@ -75,7 +77,22 @@ rl.on('line', (line) => {
     }
     if (line.indexOf('Alpha:') > -1) {
       message = line.match(/Alpha:(.*?)$/)[1].trim();
-      trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
+      if (useTimestamp) {
+        if (message.match(/\d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/)) {
+          timeString = message.match(/\d+ \w+ \d+ \d{2}:\d{2}:\d{2}/)[0];
+          if (moment(timeString, 'DD MMMM YYYY HH:mm:ss').isValid()) {
+            datetime = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
+            message = message.replace(/\d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/,'');
+          }
+        } else if (message.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)) {
+          timeString = message.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)[0];
+          if (moment(timeString).isValid()) {
+            datetime = moment(timeString).unix();
+            message = message.replace(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/, '');
+          }
+        }
+      }
+      trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']').trim();
     } else if (line.indexOf('Numeric:') > -1) {
       message = line.match(/Numeric:(.*?)$/)[1].trim();
       trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
@@ -85,6 +102,19 @@ rl.on('line', (line) => {
     }
   } else if (line.indexOf('FLEX: ') > -1) {
     address = line.match(/FLEX:.*?\[(\d*?)\] /)[1].trim();
+    if (useTimestamp) {
+      if (line.match(/FLEX: \d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/)) {
+        timeString = line.match(/\d+ \w+ \d+ \d{2}:\d{2}:\d{2}/)[0];
+        if (moment(timeString, 'DD MMMM YYYY HH:mm:ss').isValid()) {
+          datetime = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
+        }
+      } else if (line.match(/FLEX: \d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)) {
+        timeString = line.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)[0];
+        if (moment(timeString).isValid()) {
+          datetime = moment(timeString).unix();
+        }
+      }
+    }
     if (line.match( /( ALN | GPN | NUM)/ )) {
       if (line.match( / [0-9]{4}\/[0-9]\/F\/. / )) {
         // message is fragmented, hold onto it for next line


### PR DESCRIPTION
# Description

Parses known timestamp formats and strips them from the message, using them instead to form the timestamp metadata. This reduces duplicates in poorly configured pager environments (like NSW).

The regex might be a bit greedy, will have to see how it plays live

Fixes #72 and #57 (probably)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested in sample test script with FLEX and POCSAG messages with and without timestamps

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made

I really should comment reader.js a bit more...