### PR TITLE
Url update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix 404 error when trailing slash added to hostname in client config #223
 * Patch Total.js CVE #232
 * Message Repeat Plugin #222
+* Fix URL state not updating properly on Firefox #229
 
 # 0.2.3 - 2019-02-05
 

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -387,11 +387,17 @@ var app = angular.module('app', ['ngRoute', 'ngResource', 'ngCookies', 'angular-
         if (queryObj.page > 1)
           qArray.push('page='+queryObj.page);
 
-        var qString = '';
+        // default query string is "/" - this prevents the state from not passing on firefox
+        var qString = '/';
         if (qArray.length > 0) {
           qString = '?'+qArray.join('&');
         }
-        window.history.pushState('', '', qString);
+        // get the current query string - if it's blank or matches the one we're trying to set to, do nothing. This prevents duplicate history entries
+        var curQuery = window.location.search;
+        if (curQuery == '')
+          curQuery = '/';
+        if (curQuery != qString)
+          window.history.pushState('', '', qString);
         
         if (queryObj.q || queryObj.agency || queryObj.address) {
           Api.MessageSearch.get(queryObj).$promise.then(function(results) {


### PR DESCRIPTION
# Description

Update the pushState bits to properly work with firefox - it doesn't like blank things. Also stops duplicate states from being inserted, not sure if this was an issue in Chrome but was creating many history states in Firefox

Fixes #229 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Browse on many browsers, switch pages, observe changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



