### PR TITLE
Add's ability to select Icon Size on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.3.0 - Unreleased
 
+* Add ability to select the icon size on the homepage
 * Fix 404 error when trailing slash added to hostname in client config #223
 * Patch Total.js CVE #232
 * Message Repeat Plugin #222

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.3.0 - Unreleased
 
-* Add ability to select the icon size on the homepage
+* Add ability to select the icon size on the homepage #239
 * Fix 404 error when trailing slash added to hostname in client config #223
 * Patch Total.js CVE #232
 * Message Repeat Plugin #222

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -99,6 +99,16 @@
               </div>
             </div>
             <div class="form-group">
+              <label for="messages.iconsize" class="col-xs-4 col-sm-3 control-label">Icon Size</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="messages.iconsize" ng-model="settings.messages.iconsize" class="form-control">
+                  <option value="small">Small</option>
+                  <option value="normal">Normal</option>
+                </select>
+                <span id="helpBlock" class="help-block">Set the size of the icons on the message list.</span>
+              </div>
+            </div>
+            <div class="form-group">
               <label for="messages.pdwMode" class="col-xs-4 col-sm-3 control-label">Duplicate filtering</label>
               <div class="col-xs-8 col-sm-9">
                 <div class="checkbox">

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -14,6 +14,7 @@ router.use(function (req, res, next) {
   res.locals.hidecapcode = nconf.get('messages:HideCapcode');
   res.locals.hidesource = nconf.get('messages:HideSource');
   res.locals.apisecurity = nconf.get('messages:apiSecurity');
+  res.locals.iconsize = nconf.get('messages:iconsize')
   next();
 });
 

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -68,7 +68,11 @@
               </td>
             <% } %>
             <td class="shrink clickable-td" ng-if="message.agency" uib-popover-template="'templates/popover.html'" popover-append-to-body=true ng-click="popoverEl = 'agency'" popover-trigger="'outsideClick'">
+              <% if (iconsize == 'small') { %>
+              <span class="fa-stack fa-fw" style="color: {{message.color || 'grey'}};">
+              <% } else { %>
               <span class="fa-stack fa-lg fa-fw" style="color: {{message.color || 'grey'}};">
+              <% } %>
                 <i class="fa fa-circle fa-stack-2x"></i>
                 <i ng-if="message.icon" class="fa fa-{{message.icon}} fa-stack-1x fa-inverse"></i>
                 <i ng-if="!message.icon" class="fa fa-question fa-stack-1x fa-inverse"></i>
@@ -76,7 +80,11 @@
               <strong style="vertical-align: middle;">{{message.agency || ''}}</strong>
             </td>
             <td class="shrink" ng-if="!message.agency">
+              <% if (iconsize == 'small') { %>
+              <span class="fa-stack fa-fw" style="color: {{message.color || 'grey'}};">
+              <% } else { %>
               <span class="fa-stack fa-lg fa-fw" style="color: {{message.color || 'grey'}};">
+              <% } %>
                 <i class="fa fa-circle fa-stack-2x"></i>
                 <i ng-if="message.icon" class="fa fa-{{message.icon}} fa-stack-1x fa-inverse"></i>
                 <i ng-if="!message.icon" class="fa fa-question fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
# Description

Add's a selector to the settings screen to pick the size of icons displayed on the homepage. 

Normal Size
![image](https://user-images.githubusercontent.com/26653344/54874132-6a989e00-4e39-11e9-9cea-3e7a7ca168e8.png)

Small Size 
![image](https://user-images.githubusercontent.com/26653344/54874125-2b6a4d00-4e39-11e9-92d5-6486701866d6.png)


Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tried selecting the option, confirmed setting changes and displays correctly on homepage

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



