### PR TITLE
Remove double quote stripping 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1 - Unreleased
+
+* Remove stripping of double quotes from messages #274 @DanrwAU
+
 # 0.3.0 - Unreleased
 **Upgrade Notes:** 
 This is a major release with a complete rewrite of all database queries. 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -522,7 +522,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
         return res.send('Ignoring filtered');
       }
         var address = data.address || '0000000';
-        var message = data.message.replace(/["]+/g, '') || 'null';
+        var message = data.message || 'null';
         var datetime = data.datetime || 1;
         var timeDiff = datetime - dupeTime;
         var source = data.source || 'UNK';


### PR DESCRIPTION
# Description

Removes the section of API.js that strips double quotes from messages - Knex protects against SQLInjection so this is no longer required

Fixes #180 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Submitted messages containing SQL Statements and confirmed these were NOT executed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



