### PR TITLE
Adding POCSAG "Tone Only" support !

### DIFF
--- a/client/config/default.json
+++ b/client/config/default.json
@@ -3,5 +3,6 @@
   "hostname": "http://127.0.0.1:3000",
   "identifier": "TEST",
   "sendFunctionCode": false,
-  "useTimestamp": true
+  "useTimestamp": true,
+  "enableToneOnly": true
 }

--- a/client/reader.js
+++ b/client/reader.js
@@ -97,8 +97,8 @@ rl.on('line', (line) => {
       message = line.match(/Numeric:(.*?)$/)[1].trim();
       trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else {
-      message = false;
-      trimMessage = '';
+      message = "TONE ONLY";
+      trimMessage = message;
     }
   } else if (line.match(/FLEX[:|]/)) {
     address = line.match(/FLEX[:|] ?.*?[\[|](\d*?)[\]| ]/)[1].trim();

--- a/client/reader.js
+++ b/client/reader.js
@@ -31,6 +31,7 @@ var apikey = nconf.get('apikey');
 var identifier = nconf.get('identifier');
 var sendFunctionCode = nconf.get('sendFunctionCode') || false;
 var useTimestamp = nconf.get('useTimestamp') || true;
+var enableToneOnly = nconf.get('enableToneOnly') || true;
 
 //Check if hostname is in a valid format - currently only removes trailing slash - possibly expand to validate the whole URI? 
 if(hostname.substr(-1) === '/') {
@@ -97,8 +98,13 @@ rl.on('line', (line) => {
       message = line.match(/Numeric:(.*?)$/)[1].trim();
       trimMessage = message.replace(/<[A-Za-z]{3}>/g,'').replace(/Ä/g,'[').replace(/Ü/g,']');
     } else {
-      message = "TONE ONLY";
-      trimMessage = message;
+      if(enableToneOnly){
+        message = "TONE ONLY";
+        trimMessage = message;
+      }else{
+        message = false;
+        trimMessage = '';
+      }
     }
   } else if (line.match(/FLEX[:|]/)) {
     address = line.match(/FLEX[:|] ?.*?[\[|](\d*?)[\]| ]/)[1].trim();

--- a/client/samples/testToneOnly.sh
+++ b/client/samples/testToneOnly.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd .. && echo "POCSAG512: Address: 1000000  Function: 0 " | node ./reader.js

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -16,6 +16,7 @@
     "duplicateFiltering": true,
     "duplicateLimit": 10,
     "duplicateTime": 60,
+    "storeToneOnly": "never",
     "rotationEnabled": true,
     "rotateDays": 7,
     "rotateKeep": 4,

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -17,6 +17,7 @@
     "duplicateLimit": 10,
     "duplicateTime": 60,
     "storeToneOnly": "never",
+    "processToneOnly": "never",
     "rotationEnabled": true,
     "rotateDays": 7,
     "rotateKeep": 4,

--- a/server/knex/migrations/20190508191955_update_capcodes_table.js
+++ b/server/knex/migrations/20190508191955_update_capcodes_table.js
@@ -1,0 +1,12 @@
+
+exports.up = function(db, Promise) {
+    return db.schema.table('capcodes', function(table) {
+        table.integer('storeToneOnly').defaultTo(0);
+    });
+};
+
+exports.down = function(db, Promise) {
+    return db.schema.table('capcodes', function(table) {
+        table.dropColumn('storeToneOnly');
+    });
+};

--- a/server/knex/migrations/20200324191955_update_capcodes_table.js
+++ b/server/knex/migrations/20200324191955_update_capcodes_table.js
@@ -2,11 +2,13 @@
 exports.up = function(db, Promise) {
     return db.schema.table('capcodes', function(table) {
         table.integer('storeToneOnly').defaultTo(0);
+        table.integer('processToneOnly').defaultTo(0);
     });
 };
 
 exports.down = function(db, Promise) {
     return db.schema.table('capcodes', function(table) {
         table.dropColumn('storeToneOnly');
+        table.dropColumn('processToneOnly');
     });
 };

--- a/server/knex/migrations/20200324191955_update_capcodes_table.js
+++ b/server/knex/migrations/20200324191955_update_capcodes_table.js
@@ -2,13 +2,11 @@
 exports.up = function(db, Promise) {
     return db.schema.table('capcodes', function(table) {
         table.integer('storeToneOnly').defaultTo(0);
-        table.integer('processToneOnly').defaultTo(0);
     });
 };
 
 exports.down = function(db, Promise) {
     return db.schema.table('capcodes', function(table) {
         table.dropColumn('storeToneOnly');
-        table.dropColumn('processToneOnly');
     });
 };

--- a/server/plugins/Pushover.js
+++ b/server/plugins/Pushover.js
@@ -9,6 +9,7 @@ function run(trigger, scope, data, config, callback) {
           logger.main.error('Pushover: ' + data.address + ' No User/Group key set. Please enter User/Group Key.');
             callback();
           } else {
+            // data.isToneOnly to determine if it is a Tone only message
             var p = new push({
               user: pConf.group,
               token: config.pushAPIKEY,

--- a/server/plugins/Pushover.js
+++ b/server/plugins/Pushover.js
@@ -4,24 +4,11 @@ var logger = require('../log');
 function run(trigger, scope, data, config, callback) {
     var pConf = data.pluginconf.Pushover;
     if (pConf && pConf.enable) {
-        if (data.isToneOnly  && ( typeof config.processToneOnly == 'unknown' || config.processToneOnly.value == "never" ) ){
-          logger.main.debug("processToneOnly=NEVER")
-          callback();
-          return;
-        }
-
         //ensure key has been entered before trying to push
         if (pConf.group == 0 || pConf.group == '0' || !pConf.group) {
           logger.main.error('Pushover: ' + data.address + ' No User/Group key set. Please enter User/Group Key.');
             callback();
           } else {
-          
-            if ( data.isToneOnly && ( config.processToneOnly.value == "aliases" && ( typeof pConf.toneOnlyProcessAlias == "undefined" || !pConf.toneOnlyProcessAlias ) ) ){
-              logger.main.debug("processToneOnly=aliases and toneOnlyProcessAlias=false -> Skipped")
-              callback();
-              return;
-            }
-
             var p = new push({
               user: pConf.group,
               token: config.pushAPIKEY,

--- a/server/plugins/Pushover.js
+++ b/server/plugins/Pushover.js
@@ -4,11 +4,24 @@ var logger = require('../log');
 function run(trigger, scope, data, config, callback) {
     var pConf = data.pluginconf.Pushover;
     if (pConf && pConf.enable) {
+        if (data.isToneOnly  && ( typeof config.processToneOnly == 'unknown' || config.processToneOnly.value == "never" ) ){
+          logger.main.debug("processToneOnly=NEVER")
+          callback();
+          return;
+        }
+
         //ensure key has been entered before trying to push
         if (pConf.group == 0 || pConf.group == '0' || !pConf.group) {
           logger.main.error('Pushover: ' + data.address + ' No User/Group key set. Please enter User/Group Key.');
             callback();
           } else {
+          
+            if ( data.isToneOnly && ( config.processToneOnly.value == "aliases" && ( typeof pConf.toneOnlyProcessAlias == "undefined" || !pConf.toneOnlyProcessAlias ) ) ){
+              logger.main.debug("processToneOnly=aliases and toneOnlyProcessAlias=false -> Skipped")
+              callback();
+              return;
+            }
+
             var p = new push({
               user: pConf.group,
               token: config.pushAPIKEY,

--- a/server/plugins/Pushover.json
+++ b/server/plugins/Pushover.json
@@ -4,12 +4,25 @@
     "disable": false,
     "trigger": "message",
     "scope": "after",
+    "acceptToneOnly": true,
     "config": [ 
         {
             "name": "pushAPIKEY",
             "label": "API Key",
             "description": "Application key supplied by Pushover.",
             "type": "text",
+            "required": true
+        },
+        {
+            "name": "processToneOnly",
+            "label": "Process \"Tone only\" messages ",
+            "description": "",
+            "type": "select",
+            "options": [
+                {"value": "never", "text": "Never"},
+                {"value": "aliases", "text": "For selected aliases"},
+                {"value": "always", "text": "Always"}
+            ],
             "required": true
         }
     ],
@@ -40,6 +53,12 @@
             "description": "Pushover destination for messages",
             "type": "text",
             "required": true
+        },
+        {
+            "name": "toneOnlyProcessAlias",
+            "label": "Process \"Tone Only\" for this alias",
+            "description": "Depends on the \"Plugins Settings\" -> Pushover - > \"Process Tone only messages\". This parameter is only used if set to \"For selected aliases\".",
+            "type": "checkbox"
         },
         {
             "name": "sound",

--- a/server/plugins/Pushover.json
+++ b/server/plugins/Pushover.json
@@ -12,18 +12,6 @@
             "description": "Application key supplied by Pushover.",
             "type": "text",
             "required": true
-        },
-        {
-            "name": "processToneOnly",
-            "label": "Process \"Tone only\" messages ",
-            "description": "",
-            "type": "select",
-            "options": [
-                {"value": "never", "text": "Never"},
-                {"value": "aliases", "text": "For selected aliases"},
-                {"value": "always", "text": "Always"}
-            ],
-            "required": true
         }
     ],
     "aliasConfig": [ 
@@ -53,12 +41,6 @@
             "description": "Pushover destination for messages",
             "type": "text",
             "required": true
-        },
-        {
-            "name": "toneOnlyProcessAlias",
-            "label": "Process \"Tone Only\" for this alias",
-            "description": "Depends on the \"Plugins Settings\" -> Pushover - > \"Process Tone only messages\". This parameter is only used if set to \"For selected aliases\".",
-            "type": "checkbox"
         },
         {
             "name": "sound",

--- a/server/plugins/Pushover.json
+++ b/server/plugins/Pushover.json
@@ -22,6 +22,12 @@
             "type": "checkbox"
         },
         {
+            "name": "processToneOnly",
+            "label": "Process Tone Only messages",
+            "description": "Depends on the \"General Settings\" -> \"Process tone only\". Only used if set to \"Aliases\".",
+            "type": "checkbox"
+        },
+        {
             "name": "priority",
             "label": "Priority",
             "description": "Priority of the message",

--- a/server/plugins/pluginHandler.js
+++ b/server/plugins/pluginHandler.js
@@ -28,15 +28,22 @@ function handle(trigger, scope, data, callback) {
                 let pConfig = require(`./${plugin}.json`);
                 // check scope
                 if (pConfig.trigger == trigger && pConfig.scope == scope && !pConfig.disable) {
-//||  scope == "toneonly"
                     if ( !data.isToneOnly || ( data.isToneOnly && typeof pConfig.acceptToneOnly != 'undefined' && pConfig.acceptToneOnly ) ) {
                         logger.main.debug('RUNNING PLUGIN!');
                         let pRun = require(`./${plugin}`);
+                        pAliasConf = data.pluginconf[plugin];
+
+
+                        if( nconf.get('messages:processToneOnly') == 'aliases' && ( typeof pAliasConf.processToneOnly == "undefined" || !pAliasConf.processToneOnly ) ){
+                            logger.main.debug("processToneOnly=aliases and toneOnlyProcessAlias=false -> Skipped")
+                            cb();
+                        }else{
                             pRun.run(trigger, scope, data, conf, function(response, error) {
                                 if (error) logger.main.error(error);
                                 if (response) data = response;
                                 cb();
                             });
+                        }
                     }else{
                         logger.main.debug('Plugin does not accept "ToneOnly" messages');
                         cb();

--- a/server/plugins/pluginHandler.js
+++ b/server/plugins/pluginHandler.js
@@ -28,13 +28,19 @@ function handle(trigger, scope, data, callback) {
                 let pConfig = require(`./${plugin}.json`);
                 // check scope
                 if (pConfig.trigger == trigger && pConfig.scope == scope && !pConfig.disable) {
-                    logger.main.debug('RUNNING PLUGIN!');
-                    let pRun = require(`./${plugin}`);
-                        pRun.run(trigger, scope, data, conf, function(response, error) {
-                            if (error) logger.main.error(error);
-                            if (response) data = response;
-                            cb();
-                        });
+//||  scope == "toneonly"
+                    if ( !data.isToneOnly || ( data.isToneOnly && typeof pConfig.acceptToneOnly != 'undefined' && pConfig.acceptToneOnly ) ) {
+                        logger.main.debug('RUNNING PLUGIN!');
+                        let pRun = require(`./${plugin}`);
+                            pRun.run(trigger, scope, data, conf, function(response, error) {
+                                if (error) logger.main.error(error);
+                                if (response) data = response;
+                                cb();
+                            });
+                    }else{
+                        logger.main.debug('Plugin does not accept "ToneOnly" messages');
+                        cb();
+                    }
                 } else {
                     logger.main.debug('Plugin does not run in this scope');
                     cb();

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -81,18 +81,6 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="alias.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Process tone only message</label>
-              <div class="col-xs-8 col-sm-9">
-              <div class="checkbox">
-                <label>
-                <input type="checkbox" name="alias.processToneOnly" ng-model="alias.processToneOnly" ng-disabled="settings.messages.processToneOnly != 'aliases'" ng-true-value="1" ng-false-value="0">
-                Process "Tone only" messages for this alias.
-                </label>
-                <span id="helpBlock" class="help-block">Depends on the "General Settings" -> "Process tone only". Only works if set to "Aliases". </span>
-              </div>
-              </div>
-            </div>
-            <div class="form-group">
               <label for="alias.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only message</label>
               <div class="col-xs-8 col-sm-9">
               <div class="checkbox">

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -80,6 +80,18 @@
               </div>
               </div>
             </div>
+            <div class="form-group">
+              <label for="alias.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only message</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="alias.storeToneOnly" ng-model="alias.storeToneOnly" ng-disabled="settings.messages.storeToneOnly != 'aliases'" ng-true-value="1" ng-false-value="0">
+                Store "Tone only" messages for this alias.
+                </label>
+                <span id="helpBlock" class="help-block">Depends on the "General Settings" -> "Store tone only". Only works if set to "Aliases". </span>
+              </div>
+              </div>
+            </div>
 
 
             <h4>Plugins</h4>

--- a/server/public/templates/admin/aliasDetails.html
+++ b/server/public/templates/admin/aliasDetails.html
@@ -81,17 +81,31 @@
               </div>
             </div>
             <div class="form-group">
+              <label for="alias.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Process tone only message</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="alias.processToneOnly" ng-model="alias.processToneOnly" ng-disabled="settings.messages.processToneOnly != 'aliases'" ng-true-value="1" ng-false-value="0">
+                Process "Tone only" messages for this alias.
+                </label>
+                <span id="helpBlock" class="help-block">Depends on the "General Settings" -> "Process tone only". Only works if set to "Aliases". </span>
+              </div>
+              </div>
+            </div>
+            <div class="form-group">
               <label for="alias.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only message</label>
               <div class="col-xs-8 col-sm-9">
               <div class="checkbox">
                 <label>
-                <input type="checkbox" name="alias.storeToneOnly" ng-model="alias.storeToneOnly" ng-disabled="settings.messages.storeToneOnly != 'aliases'" ng-true-value="1" ng-false-value="0">
+                <input type="checkbox" name="alias.storeToneOnly" ng-model="alias.storeToneOnly" ng-disabled="settings.messages.storeToneOnly != 'aliases' || settings.messages.processToneOnly == 'never'" ng-true-value="1" ng-false-value="0">
                 Store "Tone only" messages for this alias.
                 </label>
-                <span id="helpBlock" class="help-block">Depends on the "General Settings" -> "Store tone only". Only works if set to "Aliases". </span>
+                <span id="helpBlock" class="help-block">Depends on the "General Settings" -> "Store tone only". Only works if set to "Aliases". <br />
+                  Depends on the "General Settings" -> "Process tone only". Only works if set to "Aliases" or "Always".</span>
               </div>
               </div>
             </div>
+            
 
 
             <h4>Plugins</h4>

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -174,6 +174,17 @@
               </div>
             </div>
             <div class="form-group">
+              <label for="messages.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only messages</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="messages.storeToneOnly" ng-model="settings.messages.storeToneOnly" class="form-control">
+                  <option value="always">Always</option>
+                  <option value="aliases">Only for selected aliases</option>
+                  <option value="never">Never</option>
+                </select>
+                <span id="helpBlock" class="help-block">Choose if you want to store "Tone only" messages. <a href="https://github.com/pagermon/pagermon/wiki/Messages">See more info about "Tone only" filtering</a></span>
+              </div>
+            </div>
+            <div class="form-group">
               <label for="messages.pdwMode" class="col-xs-4 col-sm-3 control-label">Duplicate filtering</label>
               <div class="col-xs-8 col-sm-9">
                 <div class="checkbox">

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -177,9 +177,9 @@
               <label for="messages.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only messages</label>
               <div class="col-xs-8 col-sm-9">
                 <select name="messages.storeToneOnly" ng-model="settings.messages.storeToneOnly" class="form-control">
-                  <option value="always">Always</option>
-                  <option value="aliases">Only for selected aliases</option>
                   <option value="never">Never</option>
+                  <option value="aliases">Only for selected aliases</option>
+                  <option value="always">Always</option>
                 </select>
                 <span id="helpBlock" class="help-block">Choose if you want to store "Tone only" messages. <a href="https://github.com/pagermon/pagermon/wiki/Messages">See more info about "Tone only" filtering</a></span>
               </div>

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -174,14 +174,25 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="messages.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only messages</label>
+              <label for="messages.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Process tone only messages</label>
               <div class="col-xs-8 col-sm-9">
-                <select name="messages.storeToneOnly" ng-model="settings.messages.storeToneOnly" class="form-control">
+                <select name="messages.processToneOnly" ng-model="settings.messages.processToneOnly" class="form-control">
                   <option value="never">Never</option>
                   <option value="aliases">Only for selected aliases</option>
                   <option value="always">Always</option>
                 </select>
-                <span id="helpBlock" class="help-block">Choose if you want to store "Tone only" messages. <a href="https://github.com/pagermon/pagermon/wiki/Messages">See more info about "Tone only" filtering</a></span>
+                <span id="helpBlock" class="help-block">Choose if you want to store "Tone only" messages. (Default:never) <a href="https://github.com/pagermon/pagermon/wiki/Messages">See more info about "Tone only" filtering</a></span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="messages.storeToneOnly" class="col-xs-4 col-sm-3 control-label">Store tone only messages</label>
+              <div class="col-xs-8 col-sm-9">
+                <select name="messages.storeToneOnly" ng-model="settings.messages.storeToneOnly" ng-disabled="settings.messages.processToneOnly != 'aliases' && settings.messages.processToneOnly != 'always'" class="form-control">
+                  <option value="never">Never</option>
+                  <option value="aliases">Only for selected aliases</option>
+                  <option value="always">Always</option>
+                </select>
+                <span id="helpBlock" class="help-block">Choose if you want to store "Tone only" messages.<br />Need "Process tone only messages" = "Always" or "For selected aliases" (Default:never)<br /><a href="https://github.com/pagermon/pagermon/wiki/Messages">See more info about "Tone only" filtering</a></span>
               </div>
             </div>
             <div class="form-group">

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -838,11 +838,12 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                           pluginHandler.handle('message', 'after', data, function(response) {
                             logger.main.debug(util.format('%o',response));
                             logger.main.debug('toneonlyMessage done');
-
-                            res.status(200);
-                            res.send('Tone only not stored but processed by plugins');
                           })
+                          res.status(200);
+                          res.send('Tone only not stored but processed by plugins');
                         }
+                        res.status(200);
+                        res.send('Tone only not stored and not processed by plugins');
                       }else{
                         res.status(200);
                         res.send('Ignoring filtered');

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -692,16 +692,6 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                         }
                         data.storeToneOnly = insert;
                       }
-                      /*var processing = true;
-                      if( processToneOnly == "aliases" ){
-                        if( !(typeof row !== 'undefined' && row.processToneOnly == 1 ) ){
-                          processing = false;
-                          logger.main.info('Tone only will not processed, process:aliases, address: '+address+' alias: '+row.alias);
-                        }
-                      }
-                      data.processToneOnly = processing; // Plugin can differentiate processing and store message
-                      // End Tone Only section
-                      */
                     }
 
                     if (insert == true) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -560,7 +560,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
 
     // Define if message is Tone Only
     data.isToneOnly = false;
-    if ( data.message.match(new RegExp('^(TONE ONLY)$')) ){
+    if ( data.message.length == 9 && data.message.match(new RegExp('^(TONE ONLY)$')) ){
       // Marked as "Tone only" in client reader
       data.isToneOnly = true;
     }


### PR DESCRIPTION
Added support for POCSAG "Tone only" messages (Empty message)

# User side : 
A first parameter in the options allows you to choose if you want to record "Tone only" messages, three values are possible: (Always, For selected aliases, Never), Never is by default.  
![settings](https://user-images.githubusercontent.com/9413626/57398291-ef176400-71ce-11e9-92d4-5145300e91c7.JPG)


If the choice is "For selected aliases" it becomes possible on the alias page to choose if you want to record the tone only for this alias.  
![alias](https://user-images.githubusercontent.com/9413626/57398305-f6d70880-71ce-11e9-9d46-cb08c80a925a.JPG)

Tone only as displayed like "Tone only" :)  
![show](https://user-images.githubusercontent.com/9413626/57398366-166e3100-71cf-11e9-8042-b10285e20765.JPG)

# Developer side :  
data message is now tagged with "data.isToneOnly" parameter, it can be true or false

# To be discussed
"Tone only" is stored as another message without distinction, maybe it might be interesting to add an "isToneOnly" column in the database?

# Wiki updates
I suggest to create a section "Messages"  and adding
```
# Messages
## Store "Tone Only" messages  
I can be possible to store "Tone only" message, just set option to "Always" or "For Selected aliases".
If you choose "For Selected aliases" you must check "Store Tone only"  for the desired alias.
> **Warning**, other options or plugins may choose not to store the message.
>    
> **If despite the "Always" option you do not receive the "Tone only" messages, refer to the "Client Installation" section**
```
Clients section, just add  
```
**Receving "Tone only" message.**  
To receive "Tone only" messages, make sure you do not use the "-e" setting in multimon-ng.
```
I still have to check if the "-f alpha" parameter should be removed as well, but I think so.







