### PR TITLE
Search looping fix yet again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **MySQL/MariaDB Upgrades from 0.3.0/0.3.1 aren't possible. Databases will need to be recreated and data re-imported.**
 
-**Fixes DoS Vulerability in search handling** #286 @davidmckenzie
+**Fixes DoS Vulerability in search handling** #286, #288 @davidmckenzie
 
 * Multiple Bugfixes and cleanups for Knex. Mainly around MySQL/MariaDB #281 @DanrwAU
     * Makes DB Settings required when MySQL/MariaDB Selected

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -385,29 +385,26 @@ var app = angular.module('app', ['ngRoute', 'ngResource', 'ngCookies', 'angular-
           }
         }
 
-        var qArray = [];
-        if (queryObj.q)
-          qArray.push('q='+encodeURIComponent(queryObj.q));
-        if (queryObj.address)
-          qArray.push('address='+encodeURIComponent(queryObj.address));
-        if (queryObj.agency)
-          qArray.push('agency='+encodeURIComponent(queryObj.agency));
-        if (queryObj.page > 1)
-          qArray.push('page='+encodeURIComponent(queryObj.page));
+        if (page) {
+          // if page then we have been passed a page var directly to the updateData func, which means we clicked on a page change button
+          // encoding everything prevents issues with some special chars
+          var qArray = [];
+          if (queryObj.q)
+            qArray.push('q='+encodeURIComponent(queryObj.q));
+          if (queryObj.address)
+            qArray.push('address='+encodeURIComponent(queryObj.address));
+          if (queryObj.agency)
+            qArray.push('agency='+encodeURIComponent(queryObj.agency));
+          if (queryObj.page > 1)
+            qArray.push('page='+encodeURIComponent(queryObj.page));
 
-        // default query string is "/" - this prevents the state from not passing on firefox
-        var qString = '/';
-        if (qArray.length > 0) {
-          qString = '?'+qArray.join('&');
-          //prevent loops when semicolons are used in search box
-          qString = qString.replace("%3B","")
-        }
-        // get the current query string - if it's blank or matches the one we're trying to set to, do nothing. This prevents duplicate history entries
-        var curQuery = window.location.search;
-        if (curQuery == '')
-          curQuery = '/';
-        if (curQuery != qString)
+          // default query string is "/" - this prevents the state from not passing on firefox
+          var qString = '/';
+          if (qArray.length > 0) {
+            qString = '?'+qArray.join('&');
+          }
           window.history.pushState('', '', qString);
+        }
         
         if (queryObj.q || queryObj.agency || queryObj.address) {
           Api.MessageSearch.get(queryObj).$promise.then(function(results) {


### PR DESCRIPTION
# Description

Turns out I was _way_ overthinking this. We can get rid of the comparison on states completely if we only push the state when we actually have to. Wrapping it in an `if (page)` completely removes the need to compare states, thus removing the fuckery that is URL encoding.

The state is still encoded to prevent issues with `?` and `&` etc., but there should now be a near 0 chance of looping happening.

Fixes #286

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tried to break it

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



