### PR TITLE
New Prowl plugin - Similar to Pushover.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.3 - 2019-07-11
+
+* Added Prowl-Plugin. Very similar to Pushover, but just for iOS and a little different.
+
 # 0.3.2 - 2019-05-15
 
 **MySQL/MariaDB Upgrades from 0.3.0/0.3.1 aren't possible. Databases will need to be recreated and data re-imported.**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The UI is built around a Node/Express/Angular/Bootstrap stack, while the client 
 * Native browner notifications
 * Plugin Support - Current Plugins:
     * [Pushover](https://pushover.net/) near realtime muti-device notification service
+    * [Prowl](https://prowlapp.com) near realtime iOS notification service with Apple Watch support
     * [Telegram](https://telegram.org/) near realtime cloud based multi-device messaging
     * [Discord](https://discordapp.com/) near realtime cloud based messaging service
     * [Gotify](https://gotify.net/) Self-Hosted messaging service

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "mysql": "^2.16.0",
     "nconf": "^0.8.4",
     "node-uuid": "^1.4.8",
+    "node-prowl": "latest",
     "nodemailer": "latest",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",

--- a/server/plugins/Prowl.js
+++ b/server/plugins/Prowl.js
@@ -1,0 +1,57 @@
+var Prowl = require('node-prowl');
+var logger = require('../log');
+
+function run(trigger, scope, data, config, callback) {
+    var pConf = data.pluginconf.Prowl;
+    logger.main.debug(JSON.stringify(pConf));
+    if (pConf && pConf.enable) {
+        //ensure key has been entered before trying to push
+        if (pConf.group == 0 || pConf.group == '0' || !pConf.group) {
+          logger.main.error('Prowl: ' + data.address + ' No User/Group key set. Please enter User/Group Key.');
+            callback();
+          } else {
+            var prowl =  new Prowl(pConf.group);
+
+            var payload = {};
+            
+            if (pConf.url) {
+              payload.url = pConf.url;
+            }
+
+            if (pConf.priority) {
+              payload.priority = pConf.priority.value;
+            }
+
+            if (pConf.providerkey) {
+              payload.providerkey = pConf.providerkey;
+            }
+
+            var event = data.agency+' - '+data.alias;
+            payload.description = data.message + ' \nTime: '+ new Date().toLocaleString();
+
+            if (pConf.priority == 2 || pConf.priority == '2') {
+              //emergency message
+              logger.main.info("SENDING EMERGENCY MESSAGE: PROWL");
+            }
+
+            logger.main.debug('Trying to send prowl.');
+            logger.main.debug('Event: '+event);
+            logger.main.debug('Application: '+config.application);
+            logger.main.debug('Payload: '+payload);
+            logger.main.debug(JSON.stringify(payload));
+
+            prowl.push(event, config.application, payload, function (err, remaining) {
+              if (err) { logger.main.error('Prowl:' + err); }
+              logger.main.debug('Prowl: Message sent. ' + remaining + ' messages remaining');
+              callback();
+            });
+          }
+    } else {
+        callback();
+    }
+
+}
+
+module.exports = {
+    run: run
+};

--- a/server/plugins/Prowl.json
+++ b/server/plugins/Prowl.json
@@ -1,0 +1,59 @@
+{
+    "name": "Prowl",
+    "description": "Push notifications on iOS devices. For more information, see <a href='https://www.prolapp.com/api.php' target='_blank'>Prowl documentation</a>.",
+    "disable": false,
+    "trigger": "message",
+    "scope": "after",
+    "config": [ 
+        {
+            "name": "providerkey",
+            "label": "Provider Key",
+            "description": "Provider key supplied by Prowl.",
+            "type": "text",
+            "required": false
+        },
+        {
+            "name": "application",
+            "label": "Application Name",
+            "description": "The name of the application",
+            "type": "text",
+            "required": true
+        }
+    ],
+    "aliasConfig": [ 
+        {
+            "name": "enable",
+            "label": "Enable",
+            "description": "Enable sending messages that match this alias via Prowl",
+            "type": "checkbox"
+        },
+        {
+            "name": "priority",
+            "label": "Priority",
+            "description": "Priority of the message",
+            "type": "select",
+            "options": [
+                {"value": "-2", "text": "Very Low"},
+                {"value": "-1", "text": "Moderate"},
+                {"value": "0", "text": "Normal"},
+                {"value": "1", "text": "High"},
+                {"value": "2", "text": "Emergency"}
+            ],
+            "required": true
+        },
+        {
+            "name": "group",
+            "label": "User/Group API Key",
+            "description": "Prowl destination for messages",
+            "type": "text",
+            "required": true
+        },
+        {
+            "name": "URL",
+            "label": "URL",
+            "description": "URL that get's delivered with the notification",
+            "type": "text",
+            "required": false
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds a Plugin for "Prowl" - Really similar to Pushover, just only for iOS. Looks ugly af, but works better on Apple Watch.
I should admit that the plugin itself is just a modified copy of the pushover one.

New dependency: 'node-prowl' at latest

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Production use for a few weeks.

Steps for reproduction:
Get Prowl, get your userkey, enable the plugin, input your key and an application name (required by Prowl, can be anything), go to some alias you want pushing enabled for, enter your user key (Or multiple ones comma separated) and maybe the other settings and wait for messages (or generate your own ones.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made
