### PR TITLE
Admin Show - Disable PDW mode for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixed Messages/id route #295 @SloCompTech
 * Added Prowl-Plugin. Very similar to Pushover, but just for iOS and a little different. #293 #297 @eopo
 * Fix security vulnerability - capcode route security in v0.2.2 did not account for the case sensitivity of route URIs. #292 @davidmckenzie (Thanks to TallTechDude for picking this up!)
-
+* Add Admin show - Allow admins to see messages without alais's when loged in. @marshyonline
 
 # 0.3.2 - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixed Messages/id route #295 @SloCompTech
 * Added Prowl-Plugin. Very similar to Pushover, but just for iOS and a little different. #293 #297 @eopo
 * Fix security vulnerability - capcode route security in v0.2.2 did not account for the case sensitivity of route URIs. #292 @davidmckenzie (Thanks to TallTechDude for picking this up!)
-* Add Admin show - Allow admins to see messages without alais's when loged in. @marshyonline
+* Add PDW Admin Override. Allow's admins to see messages that would normally be filtered by PDWMode, to allow creation of aliases/full visibility of received messages. #298 @marshyonline @DanrwAU
 
 # 0.3.2 - 2019-05-15
 

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -28,6 +28,7 @@
       }
     ],
     "pdwMode": false,
+    "adminShow": false,
     "HideCapcode": false,
     "HideSource": false,
     "apiSecurity": false

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -178,11 +178,11 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="messages.adminShow" class="col-xs-4 col-sm-3 control-label">Disable PDW Mode for Admin's</label>
+              <label for="messages.adminShow" class="col-xs-4 col-sm-3 control-label">PDW Mode - Admin Disable</label>
               <div class="col-xs-8 col-sm-9">
               <div class="checkbox">
                 <label>
-                <input type="checkbox" name="messages.adminShow" ng-model="settings.messages.adminShow">
+                <input type="checkbox" name="messages.adminShow" ng-model="settings.messages.adminShow" ng-disabled="!settings.messages.pdwMode">
                 When PDW Mode is enabled, use this option to show all messages to logged in user's only.
                 </label>
               </div>

--- a/server/public/templates/admin/settings.html
+++ b/server/public/templates/admin/settings.html
@@ -178,6 +178,17 @@
               </div>
             </div>
             <div class="form-group">
+              <label for="messages.adminShow" class="col-xs-4 col-sm-3 control-label">Disable PDW Mode for Admin's</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="messages.adminShow" ng-model="settings.messages.adminShow">
+                When PDW Mode is enabled, use this option to show all messages to logged in user's only.
+                </label>
+              </div>
+              </div>
+            </div>
+            <div class="form-group">
               <label for="messages.HideCapcode" class="col-xs-4 col-sm-3 control-label">Hide Capcodes</label>
               <div class="col-xs-8 col-sm-9">
               <div class="checkbox">

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -661,28 +661,40 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                             delete row.pluginconf;
                                             if (HideCapcode || apiSecurity) {
                                               //Emit full details to the admin socket
-                                              req.io.of('adminio').emit('messagePost', row);
+                                              if (pdwMode && adminShow) {
+                                                req.io.of('adminio').emit('messagePost', row);
+                                              } else if (!pdwMode) {
+                                                req.io.of('adminio').emit('messagePost', row);
+                                              }
                                               //Only emit to normal socket if HideCapcode is on and ApiSecurity is off.
                                               if (HideCapcode && !apiSecurity) {
-                                                // Emit No capcode to normal socket
-                                                row = {
-                                                  "id": row.id,
-                                                  "message": row.message,
-                                                  "source": row.source,
-                                                  "timestamp": row.timestamp,
-                                                  "alias_id": row.alias_id,
-                                                  "alias": row.alias,
-                                                  "agency": row.agency,
-                                                  "icon": row.icon,
-                                                  "color": row.color,
-                                                  "ignore": row.ignore,
-                                                  "aliasMatch": row.aliasMatch
-                                                };
-                                                req.io.emit('messagePost', row);
+                                                if (pdwMode && !row.aliasMatch) {
+                                                  //do nothing
+                                                } else {
+                                                  // Emit No capcode to normal socket
+                                                  row = {
+                                                    "id": row.id,
+                                                    "message": row.message,
+                                                    "source": row.source,
+                                                    "timestamp": row.timestamp,
+                                                    "alias_id": row.alias_id,
+                                                    "alias": row.alias,
+                                                    "agency": row.agency,
+                                                    "icon": row.icon,
+                                                    "color": row.color,
+                                                    "ignore": row.ignore,
+                                                    "aliasMatch": row.aliasMatch
+                                                  };
+                                                  req.io.emit('messagePost', row);
+                                                }
                                               }
                                             } else {
-                                              //Just emit - No Security enabled
-                                              req.io.emit('messagePost', row);
+                                              if (pdwMode && !row.aliasMatch) {
+                                                //do nothing
+                                              } else {
+                                                //Just emit - No Security enabled
+                                                req.io.emit('messagePost', row);
+                                              }
                                             }
                                           });
                                         }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -670,7 +670,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                               }
                                               //Only emit to normal socket if HideCapcode is on and ApiSecurity is off.
                                               if (HideCapcode && !apiSecurity) {
-                                                if (pdwMode && row.aliasMatch == null) {
+                                                if (pdwMode && row.aliasMatch != 1) {
                                                   //do nothing if pdwMode on and there isn't an aliasmatch
                                                 } else {
                                                   // Emit No capcode to normal socket
@@ -691,7 +691,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                                 }
                                               }
                                             } else {
-                                              if (pdwMode && row.aliasMatch == null) {
+                                              if (pdwMode && row.aliasMatch != 1) {
                                                 if (adminShow) {
                                                   req.io.of('adminio').emit('messagePost', row);
                                                 } else {
@@ -699,6 +699,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                                 }
                                               } else {
                                                 //Just emit - No Security enabled
+                                                req.io.of('adminio').emit('messagePost', row);
                                                 req.io.emit('messagePost', row);
                                               }
                                             }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -663,7 +663,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                               //Emit full details to the admin socket
                                               if (pdwMode && adminShow) {
                                                 req.io.of('adminio').emit('messagePost', row);
-                                              } else if (!pdwMode) {
+                                              } else if (!pdwMode || row.aliasMatch == 1) {
                                                 req.io.of('adminio').emit('messagePost', row);
                                               } else {
                                                 // do nothing if PDWMode on and AdminShow is disabled

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -665,11 +665,13 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                                 req.io.of('adminio').emit('messagePost', row);
                                               } else if (!pdwMode) {
                                                 req.io.of('adminio').emit('messagePost', row);
+                                              } else {
+                                                // do nothing if PDWMode on and AdminShow is disabled
                                               }
                                               //Only emit to normal socket if HideCapcode is on and ApiSecurity is off.
                                               if (HideCapcode && !apiSecurity) {
-                                                if (pdwMode && !row.aliasMatch) {
-                                                  //do nothing
+                                                if (pdwMode && row.aliasMatch == null) {
+                                                  //do nothing if pdwMode on and there isn't an aliasmatch
                                                 } else {
                                                   // Emit No capcode to normal socket
                                                   row = {
@@ -689,8 +691,12 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                                 }
                                               }
                                             } else {
-                                              if (pdwMode && !row.aliasMatch) {
-                                                //do nothing
+                                              if (pdwMode && row.aliasMatch == null) {
+                                                if (adminShow) {
+                                                  req.io.of('adminio').emit('messagePost', row);
+                                                } else {
+                                                  //do nothing
+                                                }
                                               } else {
                                                 //Just emit - No Security enabled
                                                 req.io.emit('messagePost', row);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -530,6 +530,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
     var dupeLimit = nconf.get('messages:duplicateLimit') || 0; // default 0
     var dupeTime = nconf.get('messages:duplicateTime') || 0; // default 0
     var pdwMode = nconf.get('messages:pdwMode');
+    var adminShow = nconf.get('messages:adminShow')
     var data = req.body;
         data.pluginData = {};
 
@@ -638,11 +639,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                             .as('aliasMatch')
                                         })
                                         .modify(function(queryBuilder) {
-                                          if (pdwMode) {
-                                            queryBuilder.innerJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id')
-                                          } else {
                                             queryBuilder.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id')
-                                          }
                                         })
                                         .where('messages.id', '=', result[0])
                                         .then((row) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -663,14 +663,14 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                               //Emit full details to the admin socket
                                               if (pdwMode && adminShow) {
                                                 req.io.of('adminio').emit('messagePost', row);
-                                              } else if (!pdwMode || row.aliasMatch == 1) {
+                                              } else if (!pdwMode || row.aliasMatch != null) {
                                                 req.io.of('adminio').emit('messagePost', row);
                                               } else {
                                                 // do nothing if PDWMode on and AdminShow is disabled
                                               }
                                               //Only emit to normal socket if HideCapcode is on and ApiSecurity is off.
                                               if (HideCapcode && !apiSecurity) {
-                                                if (pdwMode && row.aliasMatch != 1) {
+                                                if (pdwMode && row.aliasMatch == null) {
                                                   //do nothing if pdwMode on and there isn't an aliasmatch
                                                 } else {
                                                   // Emit No capcode to normal socket
@@ -691,7 +691,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                                                 }
                                               }
                                             } else {
-                                              if (pdwMode && row.aliasMatch != 1) {
+                                              if (pdwMode && row.aliasMatch == null) {
                                                 if (adminShow) {
                                                   req.io.of('adminio').emit('messagePost', row);
                                                 } else {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,6 +12,7 @@ router.use(function (req, res, next) {
   res.locals.login = req.isAuthenticated();
   res.locals.user = req.user || '';
   res.locals.hidecapcode = nconf.get('messages:HideCapcode');
+  res.locals.pdwmode = nconf.get('messages:pdwMode');
   res.locals.hidesource = nconf.get('messages:HideSource');
   res.locals.apisecurity = nconf.get('messages:apiSecurity');
   res.locals.iconsize = nconf.get('messages:iconsize')

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -267,9 +267,20 @@ var app = angular.module('app', ['ngRoute', 'ngResource', 'ngCookies', 'angular-
         adminSocket.close()
         <% } %>
     <%} else { %>
-      var socketMode = socket
-      socket.open();
-      adminSocket.close()
+      <% if (pdwmode) { %>
+        <% if (login) { %>
+          var socketMode = adminSocket
+          adminSocket.open();
+        <% } else { %>
+          var socketMode = socket
+          socket.open();
+          adminSocket.close()
+        <% } %>
+      <% } else { %>
+        var socketMode = socket
+        socket.open();
+        adminSocket.close()
+      <% } %>
     <% } %>	
   <% } else { %>
     <% if (login) { %>


### PR DESCRIPTION
# Description

This creates a setting called "Disable PDW Mode for Admins"
It allows logged in users to see the messages stored in the database without alias's but continues to run in PDW mode for the guests

This allows admins to find capcodes they might not have stored quickly and easyly 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by enable/disabling the following: API Sec, Hide Capcodes, PDW Mode
I ran through each mode with different combos to ensure messages still show correctly

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



