### PR TITLE
Optimize Duplicate checking queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix security vulnerability - capcode route security in v0.2.2 did not account for the case sensitivity of route URIs. #292 @davidmckenzie (Thanks to TallTechDude for picking this up!)
 * Add Agency route to the API to allow listing of distinct agencies. Not used in the application as yet. #300 @DanrwAU
 * Add PDW Admin Override. Allow's admins to see messages that would normally be filtered by PDWMode, to allow creation of aliases/full visibility of received messages. #298 @marshyonline @DanrwAU
+* Fix duplicate message checking when multiple clients are sending the same message @DanrwAU
 
 # 0.3.2 - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix security vulnerability - capcode route security in v0.2.2 did not account for the case sensitivity of route URIs. #292 @davidmckenzie (Thanks to TallTechDude for picking this up!)
 * Add Agency route to the API to allow listing of distinct agencies. Not used in the application as yet. #300 @DanrwAU
 * Add PDW Admin Override. Allow's admins to see messages that would normally be filtered by PDWMode, to allow creation of aliases/full visibility of received messages. #298 @marshyonline @DanrwAU
-* Fix duplicate message checking when multiple clients are sending the same message @DanrwAU
+* Fix duplicate message checking when multiple clients are sending the same message #301 @DanrwAU
 
 # 0.3.2 - 2019-05-15
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -582,7 +582,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                       .as('temp_tab')
                     })  
               })
-              .andWhere('message', 'like', `%${message}%`)
+              .andWhere('message', '=', message)
               .andWhere('address', '=', address)
             } else if ((dupeLimit !=0) && (dupeTime == 0)) {
               queryBuilder.where('id', 'in', function () {
@@ -595,7 +595,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                           .as('temp_tab')
                     })
               })
-              .andWhere('message', 'like', `%${message}%`)
+              .andWhere('message', '=', message)
               .andWhere('address', '=', address)
             } else if ((dupeLimit == 0) && (dupeTime != 0)) {
               queryBuilder.where('id', 'in', function () {
@@ -603,10 +603,10 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                     .from('messages')
                     .where('timestamp', '>', timeDiff)
               })
-              .andWhere('message', 'like', `%${message}%`)
+              .andWhere('message', '=', message)
               .andWhere('address', '=', address)
             } else {
-              queryBuilder.where('message', 'like', `%${message}%`)
+              queryBuilder.where('message', '=', message)
                           .andWhere('address', '=', address)
             }
           })
@@ -618,7 +618,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
             } else {
               db.from('capcodes')
                   .select('id', 'ignore')
-                .whereRaw(`"${address}" LIKE address`)
+                  .where('address', '=', address)
                   .orderByRaw("REPLACE(address, '_', '%') DESC")
                   .then((row) => {
                     var insert;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -582,7 +582,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                       .as('temp_tab')
                     })  
               })
-              .andWhere('message', 'like', message)
+              .andWhere('message', 'like', `%${message}%`)
               .andWhere('address', '=', address)
             } else if ((dupeLimit !=0) && (dupeTime == 0)) {
               queryBuilder.where('id', 'in', function () {
@@ -595,7 +595,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                           .as('temp_tab')
                     })
               })
-              .andWhere('message', 'like', message)
+              .andWhere('message', 'like', `%${message}%`)
               .andWhere('address', '=', address)
             } else if ((dupeLimit == 0) && (dupeTime != 0)) {
               queryBuilder.where('id', 'in', function () {
@@ -603,10 +603,10 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
                     .from('messages')
                     .where('timestamp', '>', timeDiff)
               })
-              .andWhere('message', 'like', message)
+              .andWhere('message', 'like', `%${message}%`)
               .andWhere('address', '=', address)
             } else {
-              queryBuilder.where('message', 'like', message)
+              queryBuilder.where('message', 'like', `%${message}%`)
                           .andWhere('address', '=', address)
             }
           })

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -618,7 +618,7 @@ router.post('/messages', isLoggedIn, function(req, res, next) {
             } else {
               db.from('capcodes')
                   .select('id', 'ignore')
-                  .where('address', '=', address)
+                  .whereRaw(`"${address}" LIKE address`)
                   .orderByRaw("REPLACE(address, '_', '%') DESC")
                   .then((row) => {
                     var insert;


### PR DESCRIPTION
# Description

Possible fix for the duplicate message checking issues introduce in v0.3.0 and Knex when using multiple receivers. 

Doesn't Fix #264 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running this in one of my production environments and seeing significantly better dupe checking. Would like feedback from others who were seeing this issue before calling it fixed though.

@s3m1s0n1c can you try this one out and see if your still seeing dupes?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



