### PR TITLE
Fix MessageRepeat error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.4 - Unreleased
+
+* Fix error handling of messagerepeat plugin #304 @DanrwAU
+
 # 0.3.3 - 2019-08-14
 
 * Fixed Messages/id route #295 @SloCompTech

--- a/server/plugins/MessageRepeat.js
+++ b/server/plugins/MessageRepeat.js
@@ -49,7 +49,7 @@ function run (trigger, scope, data, config, callback) {
         } else if (!error && response.statusCode === 200) {
           logger.main.info('MessageRepeat: Message Sent')
         } else {
-          logger.main.error('MessageRepeat: ' + error + ' ' +  response.statusCode + ' ' +  response.statusText)
+          logger.main.error('MessageRepeat: Status Code:' +  response.statusCode)
         }
       })
   }

--- a/server/plugins/MessageRepeat.js
+++ b/server/plugins/MessageRepeat.js
@@ -45,7 +45,7 @@ function run (trigger, scope, data, config, callback) {
         form: messageData
       }, function (error, response, body) {
         if (error && response === undefined) {
-          logger.main.error('MessageRepeat: ' + error.errno)
+          logger.main.error('MessageRepeat: Status Code:' + error.errno)
         } else if (!error && response.statusCode === 200) {
           logger.main.info('MessageRepeat: Message Sent')
         } else {

--- a/server/plugins/MessageRepeat.js
+++ b/server/plugins/MessageRepeat.js
@@ -44,10 +44,12 @@ function run (trigger, scope, data, config, callback) {
         },
         form: messageData
       }, function (error, response, body) {
-        if (!error && response.statusCode === 200) {
+        if (error && response === undefined) {
+          logger.main.error('MessageRepeat: ' + error.errno)
+        } else if (!error && response.statusCode === 200) {
           logger.main.info('MessageRepeat: Message Sent')
         } else {
-          logger.main.error('MessageRepeat: ' + error + response.statusCode + response.statusText)
+          logger.main.error('MessageRepeat: ' + error + ' ' +  response.statusCode + ' ' +  response.statusText)
         }
       })
   }


### PR DESCRIPTION
# Description

Fixes error handling of the message repeat plugin.

Previous handling relied on an HTML response, if none was found would crash the application. 

Fixes #289 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the following errors
404
401
504 

All throw the correct response

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



