### PR TITLE
Vulnerability Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix error handling of messagerepeat plugin #304 @DanrwAU
 * Add support for Azure Application Insights #306 @DanrwAU
+* Fix Vulnerability in capcodeCheck route leaking capcodes and plugin data #308 @DanrwAU @marshyonline
 
 # 0.3.3 - 2019-08-14
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1002,7 +1002,7 @@ function inParam (sql, arr) {
 // route middleware to make sure a user is logged in
 function isLoggedIn(req, res, next) {
   if (req.method == 'GET') { 
-    if (apiSecurity || req.url.match(/capcodes/i) && !(req.url.match(/agency$/))) { //check if Secure mode is on, or if the route is a capcode route
+    if (apiSecurity || ((req.url.match(/capcodes/i) || req.url.match(/capcodeCheck/i)) && !(req.url.match(/agency$/))) ) { //check if Secure mode is on, or if the route is a capcode route
       if (req.isAuthenticated()) {
         // if user is authenticated in the session, carry on
         return next();


### PR DESCRIPTION
# Description

Fixes the CapcodeCheck route leaking capcode data regardless of the HideCapcode setting, also leaks plugin data. 

Change protects this route the same as /capcodes/ - as this route is administrative only, should be hidden always. 

This one belongs to @marshyonline for discovering, bug was caused by me to begin with so i fixed it 😁 

This vulnerability may have been exploited in the wild to retrieve capcodes from protected instances. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested to ensure 401 is returned when capcodeCheck route is requested when logged out. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



