### PR TITLE
Login Failed URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add Knex logging to Winston #311 @DanrwAU
 * Fix incorrect setting in default.json #310 @DanrwAU
 * Add Google Analytics Support @Marshyonline
+* Add Login_Failed to failed login URL to allow Log Scanners to detect failed logins eaiser. @marshyonline
 
 # 0.3.4 - 2019-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add Knex logging to Winston #311 @DanrwAU
 * Fix incorrect setting in default.json #310 @DanrwAU
 * Add Google Analytics Support @Marshyonline
-* Add Login_Failed to failed login URL to allow Log Scanners to detect failed logins eaiser. @marshyonline
+* Add Login_Failed to failed login URL to allow Log Scanners to detect failed logins easier. @marshyonline
 
 # 0.3.4 - 2019-08-22
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -36,7 +36,7 @@ router.route('/login')
     // process the login form
     .post(passport.authenticate('local-login', {
         successRedirect : '/admin', // redirect to the secure profile section
-        failureRedirect : '/login', // redirect back to the signup page if there is an error
+        failureRedirect : '/login?=login_failed', // redirect back to the signup page if there is an error
         failureFlash : true // allow flash messages
     }));
     


### PR DESCRIPTION
# Description

Adds "?=login_failed" to the end of the URL when logins fail.
This will allow easier detection of failed logins and brute forcing 

Fixes # N/A

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Logins Still work, Failed logins still show the failed flash message along with the new URL

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



