### PR TITLE
Footer URL Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add Knex logging to Winston #311 @DanrwAU
 * Fix incorrect setting in default.json #310 @DanrwAU
 * Add Google Analytics Support @Marshyonline
+* Change Footer link to Pagermon Repo to a TinyCC Redirect URL @marshyonline
 
 # 0.3.4 - 2019-08-22
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,4 @@
-var version = "0.3.4-beta";
+var version = "0.3.5-beta";
 var release = 20190106;
 
 var debug = require('debug')('pagermon:server');

--- a/server/views/global/footer.ejs
+++ b/server/views/global/footer.ejs
@@ -6,7 +6,7 @@
           <% if(typeof version != 'undefined'){ %>
             <%=version%>
           <% } %></span>
-        <span class="pull-right text-muted"><a href="https://github.com/pagermon/pagermon" target="_blank"><i class="fa fa-2x fa-github" style=" vertical-align: middle;"></i> <span >GitHub</span></a></span>
+        <span class="pull-right text-muted"><a href="http://tiny.cc/pagermon" target="_blank"><i class="fa fa-2x fa-github" style=" vertical-align: middle;"></i> <span >GitHub</span></a></span>
     </div>
   </div>
 </footer>

--- a/server/views/global/footer.ejs
+++ b/server/views/global/footer.ejs
@@ -6,7 +6,7 @@
           <% if(typeof version != 'undefined'){ %>
             <%=version%>
           <% } %></span>
-        <span class="pull-right text-muted"><a href="http://tiny.cc/pagermon" target="_blank"><i class="fa fa-2x fa-github" style=" vertical-align: middle;"></i> <span >GitHub</span></a></span>
+        <span class="pull-right text-muted"><a href="https://github.com/pagermon/pagermon" rel="noreferrer" target="_blank"><i class="fa fa-2x fa-github" style=" vertical-align: middle;"></i> <span >GitHub</span></a></span>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
# Description

Changes the link to the PagerMon repo in the footer to use a TinyCC URL.
The idea behind this is to stop protected instances showing in GitHub's Traffic Stats showing where people have visited the repo from.

Fixes # N/A

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Following the Github link still works!


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



