### PR TITLE
serialise migration code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * GA De-Dupe - Resolved Dupe GA Hits. @marshyonline
 * Add front page popout. @marshyonline
 * Fix mixed content errors on admin panel @davidmckenzie
+* Fix Knex serialisation #343 @davidmckenzie
 
 # 0.3.5 - 2019-09-06
 

--- a/server/db.js
+++ b/server/db.js
@@ -41,20 +41,20 @@ function init() {
         })
         db.migrate.currentVersion().then((result) => {
             logger.main.info("Current DB version: " + result);
+            logger.main.info('Checking for database upgrades')
+            db.migrate.latest()
+            .then((result) => {
+                if (result[0] === 1) {
+                    logger.main.info('Database upgrades complete')
+                } else if (result[0] === 2) {
+                    logger.main.info('Database upgrade not required')
+                }
+            })
+            .catch((err) => {
+                logger.main.error('Error upgrading database:' + err)
+            })
         }).catch((err) => {
             logger.main.error('Error retrieving database version' + err)
-        })
-        logger.main.info('Checking for database upgrades')
-        db.migrate.latest()
-        .then((result) => {
-            if (result[0] === 1) {
-                logger.main.info('Database upgrades complete')
-            } else if (result[0] === 2) {
-                logger.main.info('Database upgrade not required')
-            }
-        })
-        .catch((err) => {
-            logger.main.error('Error upgrading database:' + err)
         })
     } else {
         logger.main.info('Checking for database upgrades')


### PR DESCRIPTION
# Description

Fixes issue with serialisation of migration code - knex will try and create the knex_migrations table when running `db.migrate.currentVersion()` if it does not exist

Fixes #343

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)