### PR TITLE
Docker: Fix for saving config in docker if changed UID,GID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed FontAwesome to v5.13.0 + Switched to cdnjs.cloudflare.com to serve #365 @MaxwellDPS
 * Docker Improvements and Auto-build with dockerhub #367 @SloCompTech
 * Add FontAwesome Shims to make 0.3.7 non-breaking #369 @DanrwAU
+* Docker: Fix for saving config in docker if changed UID,GID #376 @SloCompTech
 
 # 0.3.6 - 2020-03-19
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -75,6 +75,6 @@ RUN apk add --no-cache sqlite && \
     apk del .build-dependencies && \
     # Link config file to config dir
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/config.json /app/config/config.json && \
-		sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
+    sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} cp /app/config/default.json /defaults/config.json && \
     sed -i 's/"\.\/messages\.db.*"/"\/config\/messages\.db"/' /defaults/config.json

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -75,5 +75,6 @@ RUN apk add --no-cache sqlite && \
     apk del .build-dependencies && \
     # Link config file to config dir
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/config.json /app/config/config.json && \
+		sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} cp /app/config/default.json /defaults/config.json && \
     sed -i 's/"\.\/messages\.db.*"/"\/config\/messages\.db"/' /defaults/config.json

--- a/server/Dockerfile.armhf
+++ b/server/Dockerfile.armhf
@@ -77,6 +77,6 @@ RUN apk add --no-cache sqlite && \
     apk del .build-dependencies && \
     # Link config file to config dir
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/config.json /app/config/config.json && \
-		sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
+    sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} cp /app/config/default.json /defaults/config.json && \
     sed -i 's/"\.\/messages\.db.*"/"\/config\/messages\.db"/' /defaults/config.json

--- a/server/Dockerfile.armhf
+++ b/server/Dockerfile.armhf
@@ -77,5 +77,6 @@ RUN apk add --no-cache sqlite && \
     apk del .build-dependencies && \
     # Link config file to config dir
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/config.json /app/config/config.json && \
+		sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} ln -s /config/backup.json /app/config/backup.json && \
     sudo -u ${CONTAINER_USER} -g ${CONTAINER_USER} cp /app/config/default.json /defaults/config.json && \
     sed -i 's/"\.\/messages\.db.*"/"\/config\/messages\.db"/' /defaults/config.json


### PR DESCRIPTION
# Description

- Linked `backup.json` to `/config` in docker so it is stored in volume and doesn't cause error, when running with changed UID,GID.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Improvements

# How Has This Been Tested?

Tested on PC and RPi.

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x  ] I have commented my code, particularly in hard-to-understand areas
