### PR TITLE
Fix button export button on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add CSV Export for Aliases #383 @DanrwAU
 * Add Theme support #385 @DanrwAU
 * Docker documentation update #387 @SloCompTech
+* Fix button sizings from #383 #388 @DanrwAU
 
 # 0.3.7 - 2020-04-21
 

--- a/server/themes/default/public/stylesheets/style.css
+++ b/server/themes/default/public/stylesheets/style.css
@@ -172,7 +172,7 @@ a:hover, a:focus {
 #buttons-functions {
     text-align: center;
     position: fixed;
-    bottom:280px; 
+    bottom:200px; 
     right:50px;
     width: 225px;
 }
@@ -226,6 +226,14 @@ a:hover, a:focus {
         text-align: center;
         position: fixed;
         bottom:280px; 
+        right:50px;
+        width: 140px;
+    }
+
+    #buttons-functions {
+        text-align: center;
+        position: fixed;
+        bottom:200px; 
         right:50px;
         width: 140px;
     }


### PR DESCRIPTION
# Description

Make the export button be smaller on mobile, to match other buttons

Fixes #386 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

![image](https://user-images.githubusercontent.com/26653344/80295206-45046380-87b4-11ea-9361-ebb6986c43d4.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



