### PR TITLE
Adds option to rename your installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add Theme support #385 @DanrwAU
 * Docker documentation update #387 @SloCompTech
 * Implement FontAwesome 5 #389 @Maaaaattee @DanrwAU 
+* Readability update #390 @RyanUnderwood
+* Add title support #391 @RyanUnderwood
 
 # 0.3.7 - 2020-04-21
 

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -6,7 +6,8 @@
     "frontPopupTitle": "",
     "frontPopupContent": "",
     "searchLocation": "bottom",
-    "theme": "default"
+    "theme": "default",
+    "monitorName": "PagerMon"
   },
   "database": {
     "file": "./messages.db",

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -10,6 +10,7 @@ require('../config/passport')(passport); // pass passport for configuration
 
 router.use(function (req, res, next) {
   res.locals.login = req.isAuthenticated();
+  res.locals.monitorName = nconf.get("global:monitorName");
   next();
 });
 
@@ -27,7 +28,7 @@ router.use(bodyParser.urlencoded({     // to support URL-encoded bodies
 router.route('/login')
     .get(function(req, res, next) {
        res.render('login', { 
-           title: 'PagerMon - Login',
+           pageTitle: 'Login',
            message: req.flash('loginMessage'),
            user: req.user
        }); 
@@ -98,7 +99,7 @@ router.route('/settingsData')
     });
 
 router.get('*', isLoggedIn, function(req, res, next) {
-  res.render('admin', { title: 'PagerMon - Admin' });
+  res.render('admin', { pageTitle: 'Admin' });
 });
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -22,6 +22,7 @@ router.use(function (req, res, next) {
   res.locals.frontPopupTitle = nconf.get('global:frontPopupTitle');
   res.locals.frontPopupContent = nconf.get('global:frontPopupContent');
   res.locals.searchLocation = nconf.get('global:searchLocation');
+  res.locals.monitorName = nconf.get("global:monitorName");
   next();
 });
 
@@ -32,7 +33,7 @@ router.route('/login')
             user = req.user;
         }
        res.render('login', { 
-           title: 'PagerMon - Login',
+           pageTitle: 'Login',
            message: req.flash('loginMessage'),
            user: user
        }); 
@@ -54,13 +55,13 @@ router.get('/testLogin', isLoggedIn, function(req, res) {
         console.log(req.user);
         res.render('index', {
             user : req.user, // get the user out of session and pass to template
-            title: 'PagerMon'
+            pageTitle: 'Home'
         });
     });
     
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { title: 'PagerMon' });
+  res.render('index', { pageTitle: 'Home' });
 });
 
 module.exports = router;

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -55,6 +55,13 @@
               </div>
             </div>
             <div class="form-group">
+              <label for="global.searchLocation" class="col-xs-4 col-sm-3 control-label">Monitor Name</label>
+              <div class="col-xs-8 col-sm-9">
+                  <input class="form-control" type="text" name="global.monitorName" ng-model="settings.global.monitorName">
+                <span id="helpBlock" class="help-block">Set the title of your PagerMon website</span>
+              </div>
+            </div>
+            <div class="form-group">
               <label for="global.frontPopupEnable" class="col-xs-4 col-sm-3 control-label">Enable One Time Modal</label>
               <div class="col-xs-8 col-sm-9">
                 <div class="checkbox">

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -55,7 +55,7 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="global.searchLocation" class="col-xs-4 col-sm-3 control-label">Monitor Name</label>
+              <label for="global.monitorName" class="col-xs-4 col-sm-3 control-label">Monitor Name</label>
               <div class="col-xs-8 col-sm-9">
                   <input class="form-control" type="text" name="global.monitorName" ng-model="settings.global.monitorName">
                 <span id="helpBlock" class="help-block">Set the title of your PagerMon website</span>

--- a/server/themes/default/views/global/header.ejs
+++ b/server/themes/default/views/global/header.ejs
@@ -1,6 +1,6 @@
   <head>
     <meta charset="utf-8">
-    <title><%= title %></title>
+    <title><%= monitorName %> <% if ( typeof pageTitle !== 'undefined') { %> | <%= pageTitle %> <% } %></title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=yyx75bRMkG">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=yyx75bRMkG">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=yyx75bRMkG">

--- a/server/themes/default/views/global/menu.ejs
+++ b/server/themes/default/views/global/menu.ejs
@@ -4,7 +4,7 @@
       <button type="button" class="navbar-toggle btn-xs" data-toggle="collapse" data-target="#myNavbar">
         <i class="fa fa-bars fa-2x" aria-label="toggle menu"></i>
       </button>
-      <a class="navbar-brand" href="/">PagerMon</a></a></a>
+      <a class="navbar-brand" href="/"><% if (typeof monitorName == undefined) { %> PagerMon <% } else { %><%= monitorName %><% } %></a></a></a>
     </div>
     <div class="collapse navbar-collapse" id="myNavbar">
       <ul class="nav navbar-nav">


### PR DESCRIPTION
# Description

Seems like a nice addition to customize your installation. Defaults to 'PagerMon' otherwise. Individual pages now pass along pageTitle piped next to installation's name in <title>.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Checked no errors in each type of page. Settings submit working fine.

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x  ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have updated changelog.md with changes made



