### PR TITLE
Add CSV Import to capcodes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add Theme support #385 @DanrwAU
 * Docker documentation update #387 @SloCompTech
 * Implement FontAwesome 5 #389 @Maaaaattee @DanrwAU 
+* Add CSV Import for Aliases #392 @DanrwAU
 
 # 0.3.7 - 2020-04-21
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1007,26 +1007,26 @@ router.post('/capcodeRefresh', isLoggedIn, function(req, res, next) {
   })
 });
 
-router.post('/capcodeExport', isLoggedIn, function(req, res, next) {
+router.post('/capcodeExport', isLoggedIn, function (req, res, next) {
   nconf.load();
   var dbtype = nconf.get('database:type');
   var filename = 'export.csv'
   db.from('capcodes')
     .select('*')
-    .modify(function(queryBuilder) {
+    .modify(function (queryBuilder) {
       if (dbtype == 'oracledb')
         queryBuilder.orderByRaw(`REPLACE("address", '_', '%')`);
       else
         queryBuilder.orderByRaw(`REPLACE(address, '_', '%')`)
     })
     .then((rows) => {
-      converter.json2csv(rows, function(err, data) {
+      converter.json2csv(rows, function (err, data) {
         if (err) {
           res.status(500).send(err);
         } else {
           res.status(200).send({ 'status': 'ok', 'data': data })
         }
-      }) 
+      })
     })
     .catch((err) => {
       logger.main.error(err);
@@ -1121,7 +1121,7 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
               })
             });
         };
-        
+
         let results = { "results": importresults }
         res.status(200)
         res.json(results)

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1052,7 +1052,7 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
         var icon = capcode.icon || 'question';
         var ignore = capcode.ignore || 0;
         var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
-        await db('capcodes')
+        db('capcodes')
         .returning('id')
         .where('address', '=', address)
         .first()

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1043,7 +1043,8 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
   // join data but remove the last newline to prevent the last one being malformed. 
   var importdata = req.body.join('\n').slice(0,-1);
     converter.csv2json(importdata, function (err,data) {
-      const importresults =[]
+      const importresults = {}
+      importresults.results = [];
       data.forEach (function(capcode) {
         var address = capcode.address || 0;
         var alias = capcode.alias || 'null';
@@ -1070,17 +1071,17 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
               pluginconf: pluginconf
             })
             .then ((result) => {
-              importresults.push({
-                'address': address,
-                'alias': alias,
-                'result': 'updated'
+              importresults.results.push({
+                address: address,
+                alias: alias,
+                result: 'updated'
               })
             })
             .catch ((err) => {
-              importresults.push({
-                'address': address,
-                'alias': alias,
-                'result': 'failed' + err
+              importresults.results.push({
+                address: address,
+                alias: alias,
+                result: 'failed' + err
               })
             })
           } else {
@@ -1095,30 +1096,30 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
               pluginconf: pluginconf
             })
             .then ((result) => {
-              importresults.push({
-                'address': address,
-                'alias': alias,
-                'result': 'created'
+              importresults.results.push({
+                address: address,
+                alias: alias,
+                result: 'created'
               })
             })
             .catch ((err) => {
-              importresults.push({
-                'address': address,
-                'alias': alias,
-                'result': 'failed' + err
+              importresults.results.push({
+                address: address,
+                alias: alias,
+                result: 'failed' + err
               })
             })
           }
         })
         .catch((err) => {
-          importresults.push({
+          importresults.results.push({
             'address': address,
             'alias': alias,
             'result': 'failed' + err
           })
         })
       });
-      console.log(importresults)
+      console.log(importresults.results)
       res.status(200).send({ 'status': 'ok', 'results': importresults })
     });
 });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1041,11 +1041,10 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
     req.body[key] = req.body[key].replace(/\n/g, '');
   }
   // join data but remove the last newline to prevent the last one being malformed. 
-  var importdata = req.body.join('\n').slice(0,-1);
-    converter.csv2json(importdata, function (err,data) {
-      const importresults = {}
-      importresults.results = [];
-      data.forEach (function(capcode) {
+    var importdata = req.body.join('\n').slice(0,-1);
+    converter.csv2jsonAsync(importdata, function (err,data) {
+      var importresults = [];
+        data.forEach(function(capcode) {
         var address = capcode.address || 0;
         var alias = capcode.alias || 'null';
         var agency = capcode.agency || 'null';
@@ -1053,7 +1052,7 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
         var icon = capcode.icon || 'question';
         var ignore = capcode.ignore || 0;
         var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
-        db('capcodes')
+        await db('capcodes')
         .returning('id')
         .where('address', '=', address)
         .first()
@@ -1071,14 +1070,14 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
               pluginconf: pluginconf
             })
             .then ((result) => {
-              importresults.results.push({
+              importresults.push({
                 address: address,
                 alias: alias,
                 result: 'updated'
               })
             })
             .catch ((err) => {
-              importresults.results.push({
+              importresults.push({
                 address: address,
                 alias: alias,
                 result: 'failed' + err
@@ -1096,14 +1095,14 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
               pluginconf: pluginconf
             })
             .then ((result) => {
-              importresults.results.push({
+              importresults.push({
                 address: address,
                 alias: alias,
                 result: 'created'
               })
             })
             .catch ((err) => {
-              importresults.results.push({
+              importresults.push({
                 address: address,
                 alias: alias,
                 result: 'failed' + err
@@ -1112,15 +1111,15 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
           }
         })
         .catch((err) => {
-          importresults.results.push({
+          importresults.push({
             'address': address,
             'alias': alias,
             'result': 'failed' + err
           })
         })
       });
-      console.log(importresults.results)
-      res.status(200).send({ 'status': 'ok', 'results': importresults })
+      console.log(importresults)
+      res.status(200)
     });
 });
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1035,12 +1035,70 @@ router.post('/capcodeExport', isLoggedIn, function(req, res, next) {
 });
 
 router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
-  var importdata = req.body.join('\n');
-  console.log(importdata)
+  for (var key in req.body) {
+    //remove newline chars from dataset
+    req.body[key] = req.body[key].replace(/\r/g, '');
+    req.body[key] = req.body[key].replace(/\n/g, '');
+  }
+  // join data but remove the last newline to prevent the last one being malformed. 
+  var importresults =[]
+  var importdata = req.body.join('\n').slice(0,-1);
     converter.csv2json(importdata, function (err,data) {
-      console.log(data)
+      data.forEach (function(capcode) {
+        var address = capcode.address || 0;
+        var alias = capcode.alias || 'null';
+        var agency = capcode.agency || 'null';
+        var color = capcode.color || 'black';
+        var icon = capcode.icon || 'question';
+        var ignore = capcode.ignore || 0;
+        var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
+        db('capcodes')
+        .returning('id')
+        .where('address', '=', address)
+        .first()
+        .then((rows) => { 
+          console.log(rows)
+          if (rows) {
+            db('capcodes')
+              .where('id', '=', rows.id)
+              .update({
+              address: address,
+              alias: alias,
+              agency: agency,
+              color: color,
+              icon: icon,
+              ignore: ignore,
+              pluginconf: pluginconf
+            })
+            .then ((result) => {
+            })
+            .catch ((err) => {
+            })
+          } else {
+           db('capcodes').insert({
+              id: null,
+              address: address,
+              alias: alias,
+              agency: agency,
+              color: color,
+              icon: icon,
+              ignore: ignore,
+              pluginconf: pluginconf
+            })
+            .then ((result) => {
+              console.log(result)
+            })
+            .catch ((err) => {
+              console.log(err)
+            })
+          }
+        })
+        .catch((err) => {
+          console.log(err)
+        })
+      });
+      res.status(200).send({ 'status': 'ok', 'results': importresults })
     });
-  
 });
 
 router.use([handleError]);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1125,7 +1125,7 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
         let results = { "results": importresults }
         res.status(200)
         res.json(results)
-        logger.main.debug('Import:' + importresults)
+        logger.main.debug('Import:' + JSON.stringify(importresults))
         nconf.set('database:aliasRefreshRequired', 1);
         nconf.save();
       } else {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1125,7 +1125,7 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
         let results = { "results": importresults }
         res.status(200)
         res.json(results)
-        logger.main.debug('Import:' + results)
+        logger.main.debug('Import:' + importresults)
         nconf.set('database:aliasRefreshRequired', 1);
         nconf.save();
       } else {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1042,85 +1042,102 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
   }
   // join data but remove the last newline to prevent the last one being malformed. 
     var importdata = req.body.join('\n').slice(0,-1);
-    converter.csv2json(importdata, function (err,data) {
-      var importresults = [];
-        data.forEach(function(capcode) {
-        var address = capcode.address || 0;
-        var alias = capcode.alias || 'null';
-        var agency = capcode.agency || 'null';
-        var color = capcode.color || 'black';
-        var icon = capcode.icon || 'question';
-        var ignore = capcode.ignore || 0;
-        var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
-        db('capcodes')
-        .returning('id')
-        .where('address', '=', address)
-        .first()
-        .then((rows) => { 
-          if (rows) {
-            db('capcodes')
-              .where('id', '=', rows.id)
-              .update({
-              address: address,
-              alias: alias,
-              agency: agency,
-              color: color,
-              icon: icon,
-              ignore: ignore,
-              pluginconf: pluginconf
-            })
-            .then ((result) => {
-              importresults.push({
-                address: address,
-                alias: alias,
-                result: 'updated'
-              })
-            })
-            .catch ((err) => {
-              importresults.push({
-                address: address,
-                alias: alias,
-                result: 'failed' + err
-              })
-            })
-          } else {
-           db('capcodes').insert({
-              id: null,
-              address: address,
-              alias: alias,
-              agency: agency,
-              color: color,
-              icon: icon,
-              ignore: ignore,
-              pluginconf: pluginconf
-            })
-            .then ((result) => {
-              importresults.push({
-                address: address,
-                alias: alias,
-                result: 'created'
-              })
-            })
-            .catch ((err) => {
-              importresults.push({
-                address: address,
-                alias: alias,
-                result: 'failed' + err
-              })
-            })
-          }
-        })
-        .catch((err) => {
-          importresults.push({
-            'address': address,
-            'alias': alias,
-            'result': 'failed' + err
-          })
-        })
-      });
-      console.log(importresults)
-      res.status(200)
-    });
+    converter.csv2jsonAsync(importdata) 
+             .then(async (data) => {
+              var importresults = [];
+              await data.forEach(function(capcode) {
+                  var address = capcode.address || 0;
+                  var alias = capcode.alias || 'null';
+                  var agency = capcode.agency || 'null';
+                  var color = capcode.color || 'black';
+                  var icon = capcode.icon || 'question';
+                  var ignore = capcode.ignore || 0;
+                  var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
+                  db('capcodes')
+                  .returning('id')
+                  .where('address', '=', address)
+                  .first()
+                  .then((rows) => { 
+                    if (rows) {
+                      db('capcodes')
+                        .where('id', '=', rows.id)
+                        .update({
+                        address: address,
+                        alias: alias,
+                        agency: agency,
+                        color: color,
+                        icon: icon,
+                        ignore: ignore,
+                        pluginconf: pluginconf
+                      })
+                      .then ((result) => {
+                        importresults.push({
+                          address: address,
+                          alias: alias,
+                          result: 'updated'
+                        })
+                        console.log(result)
+                        console.log(importresults)
+                      })
+                      .catch ((err) => {
+                        importresults.push({
+                          address: address,
+                          alias: alias,
+                          result: 'failed' + err
+                        })
+                        console.log(result)
+                        console.log(importresults)
+                      })
+                    } else {
+                    db('capcodes').insert({
+                        id: null,
+                        address: address,
+                        alias: alias,
+                        agency: agency,
+                        color: color,
+                        icon: icon,
+                        ignore: ignore,
+                        pluginconf: pluginconf
+                      })
+                      .then ((result) => {
+                        importresults.push({
+                          address: address,
+                          alias: alias,
+                          result: 'created'
+                        })
+                        console.log(result)
+                        console.log(importresults)
+                      })
+                      .catch ((err) => {
+                        importresults.push({
+                          address: address,
+                          alias: alias,
+                          result: 'failed' + err
+                        })
+                        console.log(result)
+                        console.log(importresults)
+                      })
+                    }
+                  })
+                  .catch((err) => {
+                    importresults.push({
+                      'address': address,
+                      'alias': alias,
+                      'result': 'failed' + err
+                    })
+                    console.log(result)
+                    console.log(importresults)
+                  })
+                  return importresults
+                });
+             })
+             .catch ((err) => {
+
+             })
+             .finally((results) => {
+              console.log('FINAL:' + results)
+              res.status(200)
+             })
 });
 
 router.use([handleError]);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1035,9 +1035,11 @@ router.post('/capcodeExport', isLoggedIn, function(req, res, next) {
 });
 
 router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
-  var importdata = req.body
+  var importdata = req.body.join('\n');
   console.log(importdata)
-  
+    converter.csv2json(importdata, function (err,data) {
+      console.log(data)
+    });
   
 });
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1076,7 +1076,6 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
                     alias: alias,
                     result: 'updated'
                   })
-                  console.log(importresults)
                 })
                 .catch((err) => {
                   importresults.push({
@@ -1084,7 +1083,6 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
                     alias: alias,
                     result: 'failed' + err
                   })
-                  console.log(importresults)
                 })
             } else {
               return db('capcodes').insert({
@@ -1103,7 +1101,6 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
                     alias: alias,
                     result: 'created'
                   })
-                  console.log(importresults)
                 })
                 .catch((err) => {
                   importresults.push({
@@ -1111,7 +1108,6 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
                     alias: alias,
                     result: 'failed' + err
                   })
-                  console.log(importresults)
                 })
             }
           })
@@ -1121,15 +1117,17 @@ router.post('/capcodeImport', isLoggedIn, function (req, res, next) {
               'alias': alias,
               'result': 'failed' + err
             })
-            console.log(importresults)
           });
       };
     })
     .catch((err) => {
-
+      res.status(500)
+      res.send(err)
     })
     .finally(() => {
+      let results = {"results": importresults}
       res.status(200)
+      res.json(results)
     })
 });
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1034,6 +1034,13 @@ router.post('/capcodeExport', isLoggedIn, function(req, res, next) {
     })
 });
 
+router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
+  var importdata = req.body
+  console.log(importdata)
+  
+  
+});
+
 router.use([handleError]);
 
 module.exports = router;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1045,7 +1045,7 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
     converter.csv2jsonAsync(importdata) 
              .then(async (data) => {
               var importresults = [];
-              await data.forEach(function(capcode) {
+              for await(capcode of data) {
                   var address = capcode.address || 0;
                   var alias = capcode.alias || 'null';
                   var agency = capcode.agency || 'null';
@@ -1053,7 +1053,7 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
                   var icon = capcode.icon || 'question';
                   var ignore = capcode.ignore || 0;
                   var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
-                  db('capcodes')
+                  await db('capcodes')
                   .returning('id')
                   .where('address', '=', address)
                   .first()
@@ -1127,15 +1127,14 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
                     })
                     console.log(result)
                     console.log(importresults)
-                  })
-                  return importresults
-                });
+                  });
+                };
              })
              .catch ((err) => {
 
              })
-             .finally((results) => {
-              console.log('FINAL:' + results)
+             .finally((importresults) => {
+              console.log('FINAL:' + importresults)
               res.status(200)
              })
 });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1042,7 +1042,7 @@ router.post('/capcodeImport', isLoggedIn, function(req, res, next) {
   }
   // join data but remove the last newline to prevent the last one being malformed. 
     var importdata = req.body.join('\n').slice(0,-1);
-    converter.csv2jsonAsync(importdata, function (err,data) {
+    converter.csv2json(importdata, function (err,data) {
       var importresults = [];
         data.forEach(function(capcode) {
         var address = capcode.address || 0;

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -139,6 +139,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
               Api.AliasImport.post(rows).$promise.then(function (response) {
                 console.log(response);
                 $scope.loading = false;
+
               }, function(response) {
                 console.log(response)
               })

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -163,7 +163,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
                       template: resultModalHtml,
                       controller: ImportController,
                       resolve: {
-                        results: $scope.results
+                        results: function () { return $scope.results }
                       }
                 });
               }, function(response) {

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -124,11 +124,11 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
       };
 
       $scope.aliasImportConfirmed = function () {
+        //$scope.loading = true;
         var filename = document.getElementById("importcsv");
         if (filename.value.length < 1) {
           
         } else {
-
           var file = filename.files[0];
           console.log(file)
           var fileSize = 0;
@@ -144,7 +144,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
               })
             }
             reader.readAsText(filename.files[0]);
-          }
+          } 
           return false;
         }
       };

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -110,7 +110,8 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
 
       $scope.aliasImport = function () {
         var modalHtml =  '<div class="modal-header"><h5 class="modal-title" id="modal-title">Impot Aliases</h5></div>';
-        var messages = '<p>Available Columns: address, alias, agency, color, icon, ignore, pluginconf <p>Required columns are "address" and "alias", all others are optional.</p>';
+        var messages = `<p>Available Columns: address, alias, agency, color, icon, ignore, pluginconf</p>
+                        <p>Required columns are "address" and "alias", all others are optional.</p>`;
             modalHtml += '<div class="modal-body"><p><input type="file" id="importcsv"/></p><p>CSV file to be imported</p>' + messages + '</div>';
             modalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="confirmImport()">Import</button><button class="btn btn-danger" ng-click="cancelImport()">Cancel</button></div>';
             var modalInstance = $uibModal.open({
@@ -139,6 +140,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
             reader.onload = function (e) {
               var rows = e.target.result.split("\n");
               Api.AliasImport.post(rows).$promise.then(function (response) {
+                console.log(response)
                 $scope.loading = false;
                 $scope.results = response.results
                 var resultModalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Import Results</h5></div>';
@@ -166,9 +168,20 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
                       controller: ImportController,
                       scope: $scope
                 });
+                
               }, function(response) {
                 $scope.loading = false;
                 console.log(response)
+                var resultModalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Import Failed</h5></div>';
+                    resultModalHtml += `<div class="modal-body">  
+                    <p>Failed to Parse CSV file, please check the file and try again!</p>
+                    `
+                    resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okfailedImport()">OK</button></div>';
+                var modalInstance = $uibModal.open( {
+                      template: resultModalHtml,
+                      controller: ImportController,
+                      scope: $scope
+                });
               })
             }
             reader.readAsText(filename.files[0]);
@@ -246,24 +259,33 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
         });
       };
       
-      var ConfirmController = function($scope, $uibModalInstance) {
-        $scope.confirmDelete = function() {
+      var ConfirmController = function ($scope, $uibModalInstance) {
+        $scope.confirmDelete = function () {
           $uibModalInstance.close();
         };
-      
-        $scope.cancelDelete = function() {
+
+        $scope.cancelDelete = function () {
           $uibModalInstance.dismiss('cancel');
         };
       };
-      
-      var ImportController = function($scope, $uibModalInstance) {
-        $scope.confirmImport = function() {
+
+      var ImportController = function ($scope, $uibModalInstance) {
+        $scope.confirmImport = function () {
           $uibModalInstance.close();
         };
-        $scope.cancelImport = function() {
+        $scope.cancelImport = function () {
           $uibModalInstance.dismiss('cancel');
         };
         $scope.okImport = function () {
+          $uibModalInstance.close();
+          $scope.aliasRefreshRequired = 1
+          $scope.alertMessage.text = 'Alias refresh required!';
+          $scope.alertMessage.type = 'alert-warning';
+          $scope.alertMessage.show = true;
+          $timeout(function () { $scope.alertMessage.show = false; }, 3000);
+          $location.url('/aliases/');
+        }
+        $scope.okfailedImport = function () {
           $uibModalInstance.close();
         }
       };

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -24,6 +24,9 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
         AliasExport: $resource('/api/capcodeExport', null, {
           'post': { method:'POST', isArray: false }
         }),
+        AliasImport: $resource('/api/capcodeImport', null, {
+          'post': { method:'POST', isArray: true }
+        }),
       };
     }])
     
@@ -105,6 +108,46 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
         });
       };
 
+      $scope.aliasImport = function () {
+        var modalHtml =  '<div class="modal-header"><h5 class="modal-title" id="modal-title">Impot Aliases</h5></div>';
+            modalHtml += '<div class="modal-body"><p><input type="file" id="importcsv"/></p><p>CSV file to be imported</p></div>';
+            modalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="confirmImport()">Import</button><button class="btn btn-danger" ng-click="cancelImport()">Cancel</button></div>';
+            var modalInstance = $uibModal.open({
+              template: modalHtml,
+              controller: ImportController
+            });
+            modalInstance.result.then(function() {
+              $scope.aliasImportConfirmed();
+            }, function () {
+              //$log.info('Modal dismissed at: ' + new Date());
+            });
+      };
+
+      $scope.aliasImportConfirmed = function () {
+        var filename = document.getElementById("importcsv");
+        if (filename.value.length < 1) {
+          
+        } else {
+
+          var file = filename.files[0];
+          console.log(file)
+          var fileSize = 0;
+          if (filename.files[0]) {
+            var reader = new FileReader();
+            reader.onload = function (e) {
+              var rows = e.target.result.split("\n");
+              Api.AliasImport.post(rows).$promise.then(function (response) {
+                console.log(response);
+                $scope.loading = false;
+              }, function(response) {
+                console.log(response)
+              })
+            }
+            reader.readAsText(filename.files[0]);
+          }
+          return false;
+        }
+      };
 
       $scope.messageDetail = function(address) {
           $location.url('/aliases/'+address);
@@ -181,6 +224,16 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
         };
       
         $scope.cancelDelete = function() {
+          $uibModalInstance.dismiss('cancel');
+        };
+      };
+      
+      var ImportController = function($scope, $uibModalInstance) {
+        $scope.confirmImport = function() {
+          $uibModalInstance.close();
+        };
+      
+        $scope.cancelImport = function() {
           $uibModalInstance.dismiss('cancel');
         };
       };

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -109,28 +109,28 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
       };
 
       $scope.aliasImport = function () {
-        var modalHtml =  '<div class="modal-header"><h5 class="modal-title" id="modal-title">Impot Aliases</h5></div>';
+        var modalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Impot Aliases</h5></div>';
         var messages = `<p>Available Columns: address, alias, agency, color, icon, ignore, pluginconf</p>
                         <p>Required columns are "address" and "alias", all others are optional.</p>`;
-            modalHtml += '<div class="modal-body"><p><input type="file" id="importcsv"/></p><p>CSV file to be imported</p>' + messages + '</div>';
-            modalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="confirmImport()">Import</button><button class="btn btn-danger" ng-click="cancelImport()">Cancel</button></div>';
-            var modalInstance = $uibModal.open({
-              template: modalHtml,
-              controller: ImportController,
-              
-            });
-            modalInstance.result.then(function() {
-              $scope.aliasImportConfirmed();
-            }, function () {
-              //$log.info('Modal dismissed at: ' + new Date());
-            });
+        modalHtml += '<div class="modal-body"><p><input type="file" id="importcsv"/></p><p>CSV file to be imported</p>' + messages + '</div>';
+        modalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="confirmImport()">Import</button><button class="btn btn-danger" ng-click="cancelImport()">Cancel</button></div>';
+        var modalInstance = $uibModal.open({
+          template: modalHtml,
+          controller: ImportController,
+
+        });
+        modalInstance.result.then(function () {
+          $scope.aliasImportConfirmed();
+        }, function () {
+          //$log.info('Modal dismissed at: ' + new Date());
+        });
       };
 
       $scope.aliasImportConfirmed = function () {
         $scope.loading = true;
         var filename = document.getElementById("importcsv");
         if (filename.value.length < 1) {
-          
+
         } else {
           var file = filename.files[0];
           console.log(file)
@@ -144,7 +144,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
                 $scope.loading = false;
                 $scope.results = response.results
                 var resultModalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Import Results</h5></div>';
-                    resultModalHtml += `<div class="modal-body">  
+                resultModalHtml += `<div class="modal-body">  
                     <table class="table table-striped">
                        <thead>
                        <tr>
@@ -162,30 +162,30 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
                         </tbody>
                       </table>
                       </div>`
-                    resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okImport()">OK</button></div>';
-                var modalInstance = $uibModal.open( {
-                      template: resultModalHtml,
-                      controller: ImportController,
-                      scope: $scope
+                resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okImport()">OK</button></div>';
+                var modalInstance = $uibModal.open({
+                  template: resultModalHtml,
+                  controller: ImportController,
+                  scope: $scope
                 });
-                
-              }, function(response) {
+
+              }, function (response) {
                 $scope.loading = false;
                 console.log(response)
                 var resultModalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Import Failed</h5></div>';
-                    resultModalHtml += `<div class="modal-body">  
+                resultModalHtml += `<div class="modal-body">  
                     <p>Failed to Parse CSV file, please check the file and try again!</p>
                     `
-                    resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okfailedImport()">OK</button></div>';
-                var modalInstance = $uibModal.open( {
-                      template: resultModalHtml,
-                      controller: ImportController,
-                      scope: $scope
+                resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okfailedImport()">OK</button></div>';
+                var modalInstance = $uibModal.open({
+                  template: resultModalHtml,
+                  controller: ImportController,
+                  scope: $scope
                 });
               })
             }
             reader.readAsText(filename.files[0]);
-          } 
+          }
           return false;
         }
       };

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -141,30 +141,30 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
               Api.AliasImport.post(rows).$promise.then(function (response) {
                 $scope.loading = false;
                 $scope.results = response.results
-                console.log($scope.results)
                 var resultModalHtml = '<div class="modal-header"><h5 class="modal-title" id="modal-title">Import Results</h5></div>';
-                var body = `  
-                  <table>
-                     <tr>
-                        <th>Address</th>
-                        <th>Alias</th>
-                        <th>Result</th>
-                      </tr>
-                      <tr ng-repeat="result in results">
-                        <td>{{ result.address }}</td>
-                        <td>{{ result.alias }}</td>
-                        <td>{{ result.result }}</td>
-                      </tr>
-                    </table>
-                    `;
-                    resultModalHtml += '<div class="modal-body">' + body + '</div>';
+                    resultModalHtml += `<div class="modal-body">  
+                    <table class="table table-striped">
+                       <thead>
+                       <tr>
+                          <th>Address</th>
+                          <th>Alias</th>
+                          <th>Result</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr ng-repeat="result in results">
+                          <td>{{ result.address }}</td>
+                          <td>{{ result.alias }}</td>
+                          <td>{{ result.result }}</td>
+                        </tr>
+                        </tbody>
+                      </table>
+                      </div>`
                     resultModalHtml += '<div class="modal-footer"><button class="btn btn-success" ng-click="okImport()">OK</button></div>';
                 var modalInstance = $uibModal.open( {
                       template: resultModalHtml,
                       controller: ImportController,
-                      resolve: {
-                        results: function () { return $scope.results }
-                      }
+                      scope: $scope
                 });
               }, function(response) {
                 $scope.loading = false;

--- a/server/themes/default/public/javascripts/admin/admin.main.js
+++ b/server/themes/default/public/javascripts/admin/admin.main.js
@@ -130,7 +130,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
         $scope.loading = true;
         var filename = document.getElementById("importcsv");
         if (filename.value.length < 1) {
-
+          // noidea i stole this code. 
         } else {
           var file = filename.files[0];
           console.log(file)
@@ -186,7 +186,7 @@ angular.module('app', ['ngRoute', 'ngResource', 'ngSanitize', 'angular-uuid', 'u
             }
             reader.readAsText(filename.files[0]);
           }
-          return false;
+          return false; //no idea what this does, was also in the code i stole and it doesn't work without it. 
         }
       };
 

--- a/server/themes/default/public/templates/admin/aliases.html
+++ b/server/themes/default/public/templates/admin/aliases.html
@@ -62,6 +62,7 @@
     </div>
   </div>
 <div class="btn-group-vertical" id="buttons-functions">
+  <button type="button" ng-click="aliasImport();" class="btn btn-success ">Import Aliases</button>
   <button type="button" ng-click="aliasExport();" class="btn btn-success ">Export Aliases</button>
 </div>
 <div class="btn-group-vertical" id="buttons-management">


### PR DESCRIPTION
# Description

Adds the ability to import CSV files for capcodes. 

Requires a header row containing at least address & alias all other fields are optional. 

There is currently no filtering for invalid headers and these are ignored (YOU HAVE BEEN WARNED!)

@pagermon/collaborators this one will need an actual review, I'm sure my code is dodgy to achieve what I have. 

Fixes #327 
## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Importing CSV's with correct header row works as expected
Trying to import CSV with no header row fails. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



