### PR TITLE
Up max CSV Import Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 0.3.8 - 2020-05-04
+﻿# 0.3.9 - Unreleased
+ 
+ * Add fix allowing for greater than 100KB CSV files #397 @DanrwAU
+ 
+ # 0.3.8 - 2020-05-04
 
 * Add CSV Export for Aliases #383 #388 @DanrwAU
 * Add Theme support #385 @DanrwAU

--- a/server/app.js
+++ b/server/app.js
@@ -129,8 +129,13 @@ var secret = nconf.get('global:sessionSecret');
 // compress all responses
 app.use(compression());
 app.use(require("morgan")("combined", { "stream": logger.http.stream }));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({
+  limit: '1mb',
+}));       // to support JSON-encoded bodies
+app.use(bodyParser.urlencoded({     
+  extended: true,
+  limit: '1mb',
+})); // to support URL-encoded bodies
 app.use(cookieParser());
 
 var sessSet = {


### PR DESCRIPTION
# Description

Allows CSV files up to 1MB in size

Fixes #396 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with 164KB CSV file with 2500 aliases. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



