### PR TITLE
Fix Multi-Delete Capcodes on MYSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * Remove errant packages that shouldn't have made the release #398 @DanrwAU
  * Fix 500 errors filling the logs with errors #398 @DanrwAU
  * Convert PMX to PM2/IO #398 @DanrwAU
+ * Add fix for Multi-Delete on MySQL DB #405 @DanrwAU
  
  # 0.3.8 - 2020-05-04
 

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -11,10 +11,14 @@ exports.up = function (db, Promise) {
                     table.dropColumn('alias_id')
                 })
                     .then(function () {
-                        return db.schema.table('messages', function (table) {
+                        return db.schema.table('', function (table) {
                             table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+                            
+                        })
+                        .then(function () {
                             nconf.set('database:aliasRefreshRequired', 1);
                             nconf.save();
+                            return Promise.resolve()
                         })
                     })
         })

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -11,7 +11,7 @@ exports.up = function (db, Promise) {
                     table.dropColumn('alias_id')
                 })
                     .then(function () {
-                        return db.schema.table('table', function (table) {
+                        return db.schema.table('messages', function (table) {
                             table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
                             nconf.set('database:aliasRefreshRequired', 1);
                             nconf.save();

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -4,15 +4,19 @@ var dbtype = nconf.get('database:type')
 exports.up = function (db, Promise) {
     if (dbtype == 'mysql') {
         return db.schema.table('messages', function (table) {
-            table.dropColumn('alias_id')
-        })
-            .then(function () {
-                return db.schema.table('table', function (table) {
-                    table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
-                    nconf.set('database:aliasRefreshRequired', 1);
-                    nconf.save();
+            table.dropForeign('alias_id')
+        }).then(function () {
+            return db.schema.table('messages', function (table) {
+                table.dropColumn('alias_id')
+            }
+                .then(function () {
+                    return db.schema.table('table', function (table) {
+                        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+                        nconf.set('database:aliasRefreshRequired', 1);
+                        nconf.save();
+                    })
                 })
-            })
+        })
     } else {
         return Promise.resolve('Not Required')
     }

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -1,0 +1,16 @@
+var nconf = require('nconf');
+var conf_file = './config/config.json';
+var dbtype = nconf.get('database:type')
+exports.up = function(db, Promise) {
+    if (dbtype == 'mysql') {
+    return db.schema.table('messages', function(table) {
+        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+      })
+    } else {
+        return Promise.resolve('Not Required')
+    }
+};
+
+exports.down = function(knex, Promise) {
+  
+};

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -5,17 +5,18 @@ exports.up = function (db, Promise) {
     if (dbtype == 'mysql') {
         return db.schema.table('messages', function (table) {
             table.dropForeign('alias_id')
-        }).then(function () {
-            return db.schema.table('messages', function (table) {
-                table.dropColumn('alias_id')
-            }
-                .then(function () {
-                    return db.schema.table('table', function (table) {
-                        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
-                        nconf.set('database:aliasRefreshRequired', 1);
-                        nconf.save();
-                    })
+        })
+            .then(function () {
+                return db.schema.table('messages', function (table) {
+                    table.dropColumn('alias_id')
                 })
+                    .then(function () {
+                        return db.schema.table('table', function (table) {
+                            table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+                            nconf.set('database:aliasRefreshRequired', 1);
+                            nconf.save();
+                        })
+                    })
         })
     } else {
         return Promise.resolve('Not Required')

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -4,7 +4,8 @@ var dbtype = nconf.get('database:type')
 exports.up = function(db, Promise) {
     if (dbtype == 'mysql') {
     return db.schema.alterTable('messages', function(table) {
-        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL').alter();
+        table.dropColumn('alias_id')
+        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
       })
     } else {
         return Promise.resolve('Not Required')

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -11,9 +11,8 @@ exports.up = function (db, Promise) {
                     table.dropColumn('alias_id')
                 })
                     .then(function () {
-                        return db.schema.table('', function (table) {
-                            table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
-                            
+                        return db.schema.table('messages', function (table) {
+                            table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL'); 
                         })
                         .then(function () {
                             nconf.set('database:aliasRefreshRequired', 1);

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -3,8 +3,8 @@ var conf_file = './config/config.json';
 var dbtype = nconf.get('database:type')
 exports.up = function(db, Promise) {
     if (dbtype == 'mysql') {
-    return db.schema.table('messages', function(table) {
-        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+    return db.schema.alterTable('messages', function(table) {
+        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL').alter();
       })
     } else {
         return Promise.resolve('Not Required')

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -1,19 +1,23 @@
 var nconf = require('nconf');
 var conf_file = './config/config.json';
 var dbtype = nconf.get('database:type')
-exports.up = function(db, Promise) {
+exports.up = function (db, Promise) {
     if (dbtype == 'mysql') {
-    return db.schema.alterTable('messages', function(table) {
-        table.dropColumn('alias_id')
-        table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
-        nconf.set('database:aliasRefreshRequired', 1);
-        nconf.save();
-      })
+        return db.schema.table('messages', function (table) {
+            table.dropColumn('alias_id')
+        })
+            .then(function () {
+                return db.schema.table('table', function (table) {
+                    table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+                    nconf.set('database:aliasRefreshRequired', 1);
+                    nconf.save();
+                })
+            })
     } else {
         return Promise.resolve('Not Required')
     }
 };
 
-exports.down = function(knex, Promise) {
-  
+exports.down = function (knex, Promise) {
+
 };

--- a/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
+++ b/server/knex/migrations/20200507165756_messages_foreignkey_fix.js
@@ -6,6 +6,8 @@ exports.up = function(db, Promise) {
     return db.schema.alterTable('messages', function(table) {
         table.dropColumn('alias_id')
         table.integer('alias_id').unsigned().references('id').inTable('capcodes').onDelete('SET NULL');
+        nconf.set('database:aliasRefreshRequired', 1);
+        nconf.save();
       })
     } else {
         return Promise.resolve('Not Required')


### PR DESCRIPTION
# Description

In some circumstances on MySQL, using the multidelete can throw an error

```
"Cannot delete or update a parent row: a foreign key constraint fails (`pagermon-test`.`messages`, CONSTRAINT `messages_alias_id_foreign` FOREIGN KEY (`alias_id`) REFERENCES `capcodes` (`id`))"
```

This recreates with column with an SET NULL on delete key.

This requires dropping the alias_id column first, which can take quite some time on a large database.
It will also require an alias refresh once the process is complete. 

Fixes # No issue created

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested Migrations on copy of my production database.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



