### PR TITLE
Add user agent strings to webhook plugins

### DIFF
--- a/server/plugins/AdvancedWebhook.js
+++ b/server/plugins/AdvancedWebhook.js
@@ -24,6 +24,7 @@ function run(trigger, scope, data, config, callback) {
     axios.post(config.URL, dat, {
       headers: {
         'Content-Type': config.contentType || 'application/json;charset=utf-8',
+        'User-Agent': 'Pagermon - Advanced Webhook Plugin'
       },
       timeout: 5000, // Timeout 5s
     }).then(res => {

--- a/server/plugins/MessageRepeat.js
+++ b/server/plugins/MessageRepeat.js
@@ -35,6 +35,7 @@ function run (trigger, scope, data, config, callback) {
       axios.post(config.repeatURI, message, {
         headers: {
           apikey: config.repeatAPIKEY,
+          'User-Agent': 'Pagermon - Message Repeat Plugin'
         },
         timeout: 5000, // Timeout 5s
       }).then(res => {

--- a/server/plugins/SimpleWebhook.js
+++ b/server/plugins/SimpleWebhook.js
@@ -21,6 +21,9 @@ function run(trigger, scope, data, config, callback) {
     logger.main.debug('SimpleWebhook: Sending to ' + config.URL + ': ' + JSON.stringify(message));
 
     axios.post(config.URL, message, {
+      headers: {
+        'User-Agent': 'Pagermon - Simple Webhook Plugin'
+      },
       timeout: 5000, // Timeout 5s
     }).then(res => {
       logger.main.info('SimpleWebhook: Message Sent');


### PR DESCRIPTION
# Description

Adds user-agent strings to plugins that use Axios. 

Fixes #  @marshyonline never opened one :badpepe:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Submitted messages and confirmed correct user agent is seen on the receiving end
```
::ffff:127.0.0.1 - - [03/Jun/2020:10:09:00 +0000] "POST /api/messages HTTP/1.1" 200 17 "-" "Pagermon - Message Repeat Plugin"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



