### PR TITLE
Fix Gotify Plugin not Working

### DIFF
--- a/server/plugins/Gotify.js
+++ b/server/plugins/Gotify.js
@@ -16,7 +16,7 @@ function run(trigger, scope, data, config, callback) {
       url = `https://${url}`; // Add https:// if not present
     if (config.port && !isNaN(config.port)) 
       url = `${url}:${parseInt(config.port, 10)}`; // Add port to the end
-    url = path.join(url, 'message'); // Append /message to URL
+    url = url + '/message'; // Append /message to URL
 
     logger.main.debug('Gotify: Sending to ' + url + ': ' + JSON.stringify(message));
 


### PR DESCRIPTION
# Description

Changed path.join to just appending using strings in the Gotify plugin as path.join doesn't seem to like URLs

Fixes #445 

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing using own instance of Gotify and Pagermon

