### PR TITLE
Fix Alias Column on iPhoneX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ﻿# 0.3.XX - TBD
 * Added EAS support, Just run multimon-ng -a EAS #432 @maxwelldps
-* Added EAS FIltering Based on FIPS and EVENT and moved [jsame to git](https://github.com/MaxwellDPS/jsame/packages/329242) And updated jSAME to 0.1.9
+* Added EAS FIltering Based on FIPS and EVENT and moved [jsame to git](https://github.com/MaxwellDPS/jsame/packages/329242) And updated jSAME to 0.1.9 #435 @MaxwellDPS
 * Fix to PDW Python ingestion script time format #439 @jjeffhendryx
 * Fix Gotify Plugin URL construction #445 @stubbers
-* Fix textAngular.css not being called in header.ejs @DingosGotMyBaby
+* Fix textAngular.css not being called in header.ejs #449 @DingosGotMyBaby
+* Fix Alias Column on iPhoneX devices #450 @DanrwAU
 
 # 0.3.10 - 2020-06-24
 

--- a/server/themes/default/views/index.ejs
+++ b/server/themes/default/views/index.ejs
@@ -139,12 +139,12 @@
               </span>
               <strong style="vertical-align: middle;"></strong>
             </td>
-            <td class="shrink noMobile noSmall clickable-td" ng-if="user"
+            <td class="shrink noMobile clickable-td" ng-if="user"
                 uib-popover-template="'templates/popover.html'" popover-append-to-body=true
                 ng-click="popoverEl = 'alias'" popover-trigger="'outsideClick'">
               <span style="color: Maroon;">{{message.alias || 'Unknown'}}</span>
             </td>
-            <td class="shrink noMobile noSmall" ng-if="!user">
+            <td class="shrink noMobile" ng-if="!user">
               <span>{{message.alias || ''}}</span>
             </td>
             <td class="expand">


### PR DESCRIPTION
# Description

Removes the small screen detection from the Alias column to show this when iPhoneX in landscape mode. 

Will still hide the column when overall device width is lower than 768px.

Fixes #438 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In production .... duh

Blisk browser to emulate iPhoneX

Portrait
![image](https://user-images.githubusercontent.com/26653344/105498450-5616dc80-5d14-11eb-936e-d5f8548d8234.png)

Landscape
![image](https://user-images.githubusercontent.com/26653344/105498546-7050ba80-5d14-11eb-8746-aca7a98713c8.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



