### PR TITLE
Fix typo in SMTP.json

### DIFF
--- a/server/plugins/SMTP.json
+++ b/server/plugins/SMTP.json
@@ -55,7 +55,7 @@
         {
             "name": "enable",
             "label": "Enable",
-            "description": "Enable sending messages that match this alias via Pushover",
+            "description": "Enable sending messages that match this alias via SMTP",
             "type": "checkbox"
         },
         {


### PR DESCRIPTION
Minor correction, likely caused by a copy/paste operation, irrelevant to function of plugin