### PR TITLE
Update Gotify.js

### DIFF
--- a/server/plugins/Gotify.js
+++ b/server/plugins/Gotify.js
@@ -1,5 +1,4 @@
 const axios = require('axios').default;
-const path = require('path');
 var logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
@@ -16,7 +15,7 @@ function run(trigger, scope, data, config, callback) {
       url = `https://${url}`; // Add https:// if not present
     if (config.port && !isNaN(config.port)) 
       url = `${url}:${parseInt(config.port, 10)}`; // Add port to the end
-    url = path.join(url, 'message'); // Append /message to URL
+    url = `${url}:/message`; // Append /message to URL
 
     logger.main.debug('Gotify: Sending to ' + url + ': ' + JSON.stringify(message));
 


### PR DESCRIPTION
# Description

When path.join() is used to append "message" to the UR,  it is causing the url to become "https:/" instead of "https://" resulting in errors. This pull request removes the use of path.join().

Fixes # (issue)
No issue opened for this.

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually tested using by watching log output of URL being used by the plugin.

