### PR TITLE
Make mysql cron adjustable from settings

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -202,7 +202,7 @@ if (dbtype == 'mysql') {
   // Get CRON from config
   var cronartime = nconf.get('database:aliasRefreshInterval');
   //If value is falsy (undefined, empty, null etc), set as default
-  if (!cronartime){cronartime = "0 5,35 * * * *"}
+  if (!cronartime){cronartime = "0 5,35 * * * *";}
   var aliasRefreshJob = require('cron').CronJob;
   new aliasRefreshJob(cronartime, function() {
     var refreshRequired = nconf.get('database:aliasRefreshRequired')

--- a/server/app.js
+++ b/server/app.js
@@ -199,7 +199,10 @@ app.use(function(err, req, res, next) {
 // Add cronjob to automatically refresh aliases
 var dbtype = nconf.get('database:type')
 if (dbtype == 'mysql') {
+  // Get CRON from config
   var cronartime = nconf.get('database:aliasRefreshInterval');
+  //If value is falsy (undefined, empty, null etc), set as default
+  if (!cronartime){cronartime = "0 5,35 * * * *"}
   var aliasRefreshJob = require('cron').CronJob;
   new aliasRefreshJob(cronartime, function() {
     var refreshRequired = nconf.get('database:aliasRefreshRequired')

--- a/server/app.js
+++ b/server/app.js
@@ -206,7 +206,7 @@ if (dbtype == 'mysql') {
   //If value is falsy (undefined, empty, null etc), set as default
   if (!cronartime){cronartime = "0 5,35 * * * *";}
   //Check value isn't garbage, if it is set to default
-  if (!cronvalidate.isValidCron(cronartime)) {
+  if (!cronvalidate.isValidCron(cronartime,{ seconds: true })) {
     logger.main.warn('CRON: Invalid CRON configuration in config file. Defaulting to: "0 5,35 * * * *" ')
     cronartime = "0 5,35 * * * *";
   } 

--- a/server/app.js
+++ b/server/app.js
@@ -25,6 +25,7 @@ var SQLiteStore = require('connect-sqlite3')(session);
 var flash    = require('connect-flash');
 
 
+
 process.on('SIGINT', function() {
     console.log( "\nGracefully shutting down from SIGINT (Ctrl-C)" );
     process.exit(1);
@@ -199,10 +200,16 @@ app.use(function(err, req, res, next) {
 // Add cronjob to automatically refresh aliases
 var dbtype = nconf.get('database:type')
 if (dbtype == 'mysql') {
+  const cronvalidate = require('cron-validator');
   // Get CRON from config
   var cronartime = nconf.get('database:aliasRefreshInterval');
   //If value is falsy (undefined, empty, null etc), set as default
   if (!cronartime){cronartime = "0 5,35 * * * *";}
+  //Check value isn't garbage, if it is set to default
+  if (!cronvalidate.isValidCron(cronartime)) {
+    logger.main.warn('CRON: Invalid CRON configuration in config file. Defaulting to: "0 5,35 * * * *" ')
+    cronartime = "0 5,35 * * * *";
+  } 
   var aliasRefreshJob = require('cron').CronJob;
   new aliasRefreshJob(cronartime, function() {
     var refreshRequired = nconf.get('database:aliasRefreshRequired')

--- a/server/app.js
+++ b/server/app.js
@@ -199,8 +199,9 @@ app.use(function(err, req, res, next) {
 // Add cronjob to automatically refresh aliases
 var dbtype = nconf.get('database:type')
 if (dbtype == 'mysql') {
+  var cronartime = nconf.get('database:aliasRefreshInterval');
   var aliasRefreshJob = require('cron').CronJob;
-  new aliasRefreshJob('0 5,35 * * * *', function() {
+  new aliasRefreshJob(cronartime, function() {
     var refreshRequired = nconf.get('database:aliasRefreshRequired')
     logger.main.debug('CRON: Running Cronjob AliasRefresh')
     if (refreshRequired == 1) {

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -11,7 +11,8 @@
   },
   "database": {
     "file": "./messages.db",
-    "type": "sqlite3"
+    "type": "sqlite3",
+    "aliasRefreshInterval": "0 1 3 * * *"
   },
   "messages": {
     "maxLimit": 120,

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -12,7 +12,7 @@
   "database": {
     "file": "./messages.db",
     "type": "sqlite3",
-    "aliasRefreshInterval": "0 1 3 * * *"
+    "aliasRefreshInterval": "0 5,35 * * * *"
   },
   "messages": {
     "maxLimit": 120,

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "cookie-parser": "~1.4.3",
     "core-js": "^2.4.1",
     "cron": "^1.7.0",
+    "cron-validator": "^1.2.1",
     "debug": "~2.6.3",
     "discord.js": "^11.6.4",
     "ejs": "~2.5.6",

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -149,7 +149,7 @@
             <div class="form-group" ng-if="settings.database.type == 'mysql'">
               <label for="database.aliasRefreshInterval" class="col-xs-4 col-sm-3 control-label">Alias Refresh CRON</label>
               <div class="col-xs-8 col-sm-9">
-              <input type="text" class="form-control" name="database.aliasRefreshInterval" ng-model="settings.database.aliasRefreshInterval" required>
+              <input type="text" class="form-control" name="database.aliasRefreshInterval" ng-model="settings.database.aliasRefreshInterval">
               <span id="helpBlock" class="help-block"><strong>Advanced Users</strong> - The cron timing for Automatic Alias Refresh. See <a href="https://www.npmjs.com/package/node-cron#cron-syntax" target="_blank">Cron Syntax</a>.<br />Default = "0 5,35 * * * *" (The 5th and 35th minute of every hour)</span>
               </div>
             </div> 

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -86,7 +86,7 @@
               </div>
             </div>
 
-            <h5>Database</h5>
+            <h5>Database</h5><span class="text-warning">These settings require restart to take effect.</span>
             <div class="form-group">
               <label for="database.type" class="col-xs-4 col-sm-3 control-label">Type</label>
               <div class="col-xs-8 col-sm-9">
@@ -146,7 +146,13 @@
                 <span id="helpBlock" class="help-block">Database Password</span>
                 </div>
             </div> 
-            
+            <div class="form-group" ng-if="settings.database.type == 'mysql'">
+              <label for="database.aliasRefreshInterval" class="col-xs-4 col-sm-3 control-label">Alias Refresh CRON</label>
+              <div class="col-xs-8 col-sm-9">
+              <input type="text" class="form-control" name="database.aliasRefreshInterval" ng-model="settings.database.aliasRefreshInterval" required>
+              <span id="helpBlock" class="help-block"><strong>Advanced Users</strong> - The cron timing for Automatic Alias Refresh. See <a href="https://www.npmjs.com/package/node-cron#cron-syntax" target="_blank">Cron Syntax</a>.<br />Default = "0 5,35 * * * *" (The 5th and 35th minute of every hour)</span>
+              </div>
+            </div> 
             <fieldset disabled>
             <div class="form-group">
               <div class="col-xs-8 col-xs-offset-2 col-sm-9 col-sm-offset-3">


### PR DESCRIPTION
# Description

After switching to mysql(mariadb) I noticed frequently while adding alias, that the database was locked. It looks like this is caused by a cron job refreshing alias every 30 minutes if a refresh is required (I'm playing with the aliases, so it is). My database is reasonably sized (200k messages?) and runs on limited hardware (Raspberry PI 3).

I considered just adjusting the cron to not refresh as often, but I decided to just add the cron job interval settings into the Settings Template instead.

Note: Probably a better way to do this. Also considered using prettyCron to display human readable translation of cron, but decided to just link cron doc instead and label it advanced

![cron_settings](https://user-images.githubusercontent.com/14150258/120352387-11472600-c344-11eb-8f66-71799fe4a6dd.png)

Fixes # cron job interval cannot be adjusted easily by admins

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added to my current server instance


