### PR TITLE
Fix layout when message contains long word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix Broken Alias Search #453 @marshyonline
 * Fix Twitter trunication at 280 chars #461 @maxwelldps
 * Fixed Typo's #465 @geelongmicrosoldering
+* Fix layout when message contains long word #474 @geelongmicrosoldering
 
 # 0.3.10 - 2020-06-24
 

--- a/server/themes/default/public/stylesheets/style.css
+++ b/server/themes/default/public/stylesheets/style.css
@@ -41,6 +41,7 @@
 
 .pagerMessage {
     font-weight: bold;
+    word-break: break-word;
 }
 
 .clickable-td {


### PR DESCRIPTION
Long words are bad.

# Description

There is an interesting result when a message contains a really long word. The page will infinitely get wider,and as a result all other messages that would have otherwise wrapped do not.

![wordbreak_pm](https://user-images.githubusercontent.com/14150258/120669724-0ec70680-c4d3-11eb-9ea7-285cb7410ff2.png)

The issue can be corrected by using word-break, and breaking a word that exceeds the width of its container. It shouldn't break other words, only those that are too long to fit. So there should be no visual change for anyone unless they encounter one of these messages.

![wordbreak_pm_after](https://user-images.githubusercontent.com/14150258/120670430-c0fece00-c4d3-11eb-89fe-17da2159b1bb.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on my own instance

