### PR TITLE
Automated Raspberry Pi Image Creation via GH Actions

### DIFF
--- a/.github/workflows/rpi_image_build.yml
+++ b/.github/workflows/rpi_image_build.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           submodules: recursive
-      - name: Build Pagermon_Pi Image
-        uses: Natur40/pimod@master
+      - name: Run PIMOD
+        uses: Nature40/pimod@v0.4.4
         with:
           pifile: builder.pifile

--- a/.github/workflows/rpi_image_build.yml
+++ b/.github/workflows/rpi_image_build.yml
@@ -1,8 +1,11 @@
-name: Build Raspberry Pi Image
-on: push
+name: Build + Upload Raspberry Pi Image to release
+on:
+  release:
+    types:
+      - created
 
 jobs:
-  build:
+  Build_Image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -13,3 +16,12 @@ jobs:
         uses: Nature40/pimod@v0.4.4
         with:
           pifile: builder.pifile
+      - name: Compress Image
+        uses: edgarrc/action-7z@v1
+        with:
+          args: 7z a -t7z -mx=9 pagermon_pi.7z /tmp/pagermon_pi.img
+      - name: Upload Asset to Release
+        uses: shogo82148/actions-upload-release-asset@v1.5.0
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: pagermon_pi.7z

--- a/.github/workflows/rpi_image_build.yml
+++ b/.github/workflows/rpi_image_build.yml
@@ -17,11 +17,13 @@ jobs:
         with:
           pifile: builder.pifile
       - name: Compress Image
-        uses: edgarrc/action-7z@v1
-        with:
-          args: 7z a -t7z -mx=9 pagermon_pi.7z /tmp/pagermon_pi.img
+        run: |
+          wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
+          chmod +x pishrink.sh
+          sudo ./pishrink.sh -vzap /tmp/pagermon-pi.img
       - name: Upload Asset to Release
-        uses: shogo82148/actions-upload-release-asset@v1.5.0
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: pagermon_pi.7z
+          asset_paths: '["/tmp/pagermon-pi.img.gz"]'

--- a/.github/workflows/rpi_image_build.yml
+++ b/.github/workflows/rpi_image_build.yml
@@ -1,0 +1,15 @@
+name: Build Raspberry Pi Image
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Build Pagermon_Pi Image
+        uses: Natur40/pimod@master
+        with:
+          pifile: builder.pifile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.11c - 2022-01-13
+# 0.3.11d - 2022-01-13
 * Fix Pagermon Pi Image Building @marshyonline (Special thanks to Wade A for his help debuging issues with Raspbery Pi's)
 
 # 0.3.11b/c - 2021-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.11c - 2022-01-13
 * Fix Pagermon Pi Image Building @marshyonline (Special thanks to Wade A for his help debuging issues with Raspbery Pi's)
 
-# 0.3.11b - 2021-12-30
+# 0.3.11b/c - 2021-12-30
 * Fix Docker Image Building @marshyonline
 
 # 0.3.11a - 2021-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.11c - 2022-01-13
+* Fix Pagermon Pi Image Building @marshyonline (Special thanks to Wade A for his help debuging issues with Raspbery Pi's)
+
+# 0.3.11b - 2021-12-30
+* Fix Docker Image Building @marshyonline
+
 # 0.3.11a - 2021-12-30
 * updated jSAME to 0.2.3 and moved to NPM from github #484 @MaxwellDPS
 

--- a/builder.pifile
+++ b/builder.pifile
@@ -1,0 +1,33 @@
+#Latest Raspios Lite as of 12/01/2021 - https://www.raspberrypi.com/software/operating-systems/
+FROM https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
+
+PUMP 200M
+# Enable SSH
+RUN touch /boot/ssh
+
+#Build Deps
+
+RUN <<EOF
+  apt-get update
+  apk add --no-cache --virtual .build-dependencies \
+        autoconf \
+        automake \
+        build-base \
+        cmake \
+        gcc \
+        g++ \
+        make \
+        musl-dev \
+        sqlite \
+        python3  
+EOF
+
+#Copy in Repo
+COPY . /home/pi/pagermon/
+
+RUN <<EOF
+  cd /home/pi/pagermon/server
+  npm install
+  cd /home/pi/pagermon/client
+  npm install
+EOF

--- a/builder.pifile
+++ b/builder.pifile
@@ -1,13 +1,14 @@
 #Latest Raspios Lite as of 12/01/2021 - https://www.raspberrypi.com/software/operating-systems/
 FROM https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
+TO /tmp/pagermon-pi.img
 
-PUMP 4096M
+PUMP 1024M
 # Enable SSH
 RUN touch /boot/ssh
 
 #Update
 RUN apt-get update
-#RUN apt-get upgrade -y
+RUN apt-get upgrade -y
 
 #Build Deps
 RUN apt-get install build-essential -y
@@ -16,13 +17,54 @@ RUN apt install -y sqlite \
         git \
         vim \
         htop \
+        curl \
+        wget \
+        unzip \
+        rtl-sdr
 
 #Copy in Repo
 INSTALL . /home/pi/pagermon/
 
-RUN <<EOF
-  cd /home/pi/pagermon/server
-  npm install
-  cd /home/pi/pagermon/client
-  npm install
-EOF
+#CHOWN pi
+RUN chown -R pi:pi /home/pi/pagermon
+
+#Install Nodejs 12.x
+RUN curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+RUN apt-get install -y nodejs npm
+
+#Install Multimon-ng
+RUN bash -c "apt install -y cmake && \
+    cd /tmp && \
+    git clone https://github.com/EliasOenal/multimon-ng.git && \
+    cd multimon-ng && \
+    git checkout 1.1.9 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    sudo make install && \
+    rm -rf /tmp/multimon-ng"
+
+#Becuase if we dont, its broken - NPM likes to use ssh?
+RUN bash -c "mkdir /root/.ssh && touch /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts"
+RUN bash -c "mkdir /home/pi/.ssh && touch /home/pi/.ssh/known_hosts && chown pi:pi /home/pi/.ssh/known_hosts && chmod 600 /home/pi/.ssh/known_hosts"
+RUN bash -c "ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts"
+RUN bash -c "ssh-keyscan -t rsa github.com >> /home/pi/.ssh/known_hosts"
+
+
+#Setup Server
+RUN sudo -u pi sed -i 's/"oracledb"\s*:\s*".*"\s*,//' /home/pi/pagermon/server/package.json
+RUN bash -c "cd /home/pi/pagermon/server && \
+    npm install --target_arch=arm --target_platform=linux && \
+    npm install npm@latest -g --target_arch=arm --target_platform=linux && \
+    npm install pm2@latest -g --target_arch=arm --target_platform=linux && \
+    sudo -u pi cp process-default.json process.json && \
+    sudo -u pi sed -i 's:/home/ubuntu/workspace/server:/home/pi/pagermon/server:g' /home/pi/pagermon/server/process.json && \
+    export NODE_ENV=production && \
+    sudo -u pi pm2 start process.json && \
+    sleep 10 && \
+    sudo -u pi pm2 stop pagermon"
+
+#Setup Client
+RUN bash -c "cd /home/pi/pagermon/client && \
+    sudo -u pi npm install --target_arch=arm --target_platform=linux"

--- a/builder.pifile
+++ b/builder.pifile
@@ -1,29 +1,24 @@
 #Latest Raspios Lite as of 12/01/2021 - https://www.raspberrypi.com/software/operating-systems/
 FROM https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
 
-PUMP 200M
+PUMP 4096M
 # Enable SSH
 RUN touch /boot/ssh
 
-#Build Deps
+#Update
+RUN apt-get update
+#RUN apt-get upgrade -y
 
-RUN <<EOF
-  apt-get update
-  apk add --no-cache --virtual .build-dependencies \
-        autoconf \
-        automake \
-        build-base \
-        cmake \
-        gcc \
-        g++ \
-        make \
-        musl-dev \
-        sqlite \
-        python3  
-EOF
+#Build Deps
+RUN apt-get install build-essential -y
+RUN apt install -y sqlite \
+        python3 \
+        git \
+        vim \
+        htop \
 
 #Copy in Repo
-COPY . /home/pi/pagermon/
+INSTALL . /home/pi/pagermon/
 
 RUN <<EOF
   cd /home/pi/pagermon/server


### PR DESCRIPTION
# Description

This removes the need for someone to manually install Pagermon on Raspbian and release it every time we push out an update.

New Pi images are built on release and take around 65mins to upload to the release itself. 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally and by installing the build image on a pi.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



