### PR TITLE
[HOTFIX ] Downgrade installed version of multimon-ng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.11e - 2022-01-19
+* [HOTFIX ] Downgrade installed version of multimon-ng @marshyonline
+
 # 0.3.11d - 2022-01-13
 * Fix Pagermon Pi Image Building @marshyonline (Special thanks to Wade A for his help debuging issues with Raspbery Pi's)
 

--- a/builder.pifile
+++ b/builder.pifile
@@ -37,7 +37,7 @@ RUN bash -c "apt install -y cmake && \
     cd /tmp && \
     git clone https://github.com/EliasOenal/multimon-ng.git && \
     cd multimon-ng && \
-    git checkout 1.1.9 && \
+    git checkout 1.1.7 && \
     mkdir build && \
     cd build && \
     cmake .. && \


### PR DESCRIPTION
Because Multimon-ng 1.1.9 is broken for POCSAG



