### PR TITLE
Automatic Alias Refresh for Specific Addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.12 - TBD
+* Refresh alias automatically when single capcode alias is updated @geelongmicrosoldering
+
 # 0.3.11e - 2022-01-19
 * [HOTFIX ] Downgrade installed version of multimon-ng @marshyonline
 

--- a/server/themes/default/public/templates/admin/settings.html
+++ b/server/themes/default/public/templates/admin/settings.html
@@ -85,6 +85,18 @@
 		            <span id="helpBlock" class="help-block">Modal Content</span>
               </div>
             </div>
+            <div class="form-group">
+              <label for="global.SpecificAliasRefresh" class="col-xs-4 col-sm-3 control-label">Refresh Specific Alias</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="global.SpecificAliasRefresh" ng-model="settings.global.SpecificAliasRefresh">
+                Refresh all messages for a specific Alias, when the Alias is saved. 
+		<span id="helpBlock" class="help-block">This mitigates the need for an Alias Refresh every time an alias is saved, but does not effect <b>_</b> wildcard alias.</span>
+                </label>
+              </div>
+              </div>
+            </div>
 
             <h5>Database</h5>
             <div class="form-group">


### PR DESCRIPTION
# Description

One of my current servers in production has over **1,000,000 messages**.
An Alias Refresh takes about **700-800 seconds**, during which the capcodes table is locked (mysql). This isn't so much due to hardware limitations, but seems to be because the refresh query performs a subquery for every message (so, over 1M queries, for which I don't have an index.) The structure of that query, and my database is probaby open for discussion, but i digress. I already [modified the alias refresh cron](https://github.com/pagermon/pagermon/pull/473)

In any case, 99% of the time, I'm adding an Alias with a specific address. That is, 1234567, not 1234___
Basically, I really only need to refresh the addresses for that specific address. If the address was previously part of a wildcard match, the other messages in the wildcard address match (say, 1234987) don't need to be refreshed.

So, I found myself manually refreshing messages every time I add an alias, using a a query like
```
update `messages` set `alias_id` = (select `id` from `capcodes` where `messages`.`address` like `capcodes`.`address` order by REPLACE(address, '_', '%') DESC limit 1) where `address` = '1234567';
```
This usually takes a **fraction of a second**, and applies immediate changes to any messages that match the alias, while leaving the others alone.

I found myself thinking, this should just be triggered when saving the alias, assuming the alias is not a wildcard match.
So, that's what I've done. Thought I'd share. It's 1am, and I'm not entirely sure this is the best way of going about it, but it seems to work well.

In testing, saving an alias still only takes a fraction of a second, except now, **thousands of matched messages immediately display the new alias.**

Just a single checkbox that triggers a refresh on messages that match your alias. Maybe needs rewording:
![specific_refresh](https://user-images.githubusercontent.com/14150258/152542443-a1b4ff90-bde5-478d-88d9-547261aa72c0.png)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have this running on 2 server, both of which are running the latest release.

- [x] Running on Production Server with over 1M messages
- [x] Running on Production Server with over 100K messages

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
