### PR TITLE
Fix failing dependencies

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -67,6 +67,8 @@ if (azureEnable) {
              .start();
 }
 
+checkForDbDriver(nconf.get('database:type'));
+
 var dbinit = require('./db');
     dbinit.init();
 var db = require('./knex/knex.js');
@@ -277,6 +279,54 @@ function onError(error) {
       throw error;
   }
 }
+
+function checkForDbDriver(driver) {
+  switch (driver) {
+    /* eslint-disable import/no-extraneous-dependencies, global-require */
+    case 'sqlite3': {
+      try {
+        require('sqlite3');
+      } catch (e) {
+        logger.main.error(`Selected database type is sqlite3, but npm package sqlite3 was not installed.`);
+        logger.main.error(
+          `Please run npm i sqlite3 to install or refer to https://www.npmjs.com/package/sqlite3 for reference`
+        );
+        process.exit(1);
+      }
+      break;
+    }
+    case 'mysql': {
+      try {
+        require('knex');
+      } catch (e) {
+        logger.main.error(`Selected database type is mysql, but npm package knex was not installed.`);
+        logger.main.error(
+          `Please run npm i knex to install or refer to https://www.npmjs.com/package/knex for reference`
+        );
+        process.exit(1);
+      }
+      break;
+    }
+    case 'oracledb': {
+      try {
+        require('oracledb');
+      } catch (e) {
+        logger.main.error(`Selected database type is oracledb, but npm package oracledb was not installed.`);
+        logger.main.error(
+          `Please run npm i oracledb to install or refer to https://www.npmjs.com/package/oracledb for reference`
+        );
+        process.exit(1);
+      }
+      break;
+    }
+    default: {
+      logger.main.error(`No database type was specified.`);
+      process.exit(1);
+    }
+  }
+  /* eslint-enable import/no-extraneous-dependencies, global-require */
+}
+
 
 function onListening() {
   var addr = server.address();

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,6 @@
     "node-prowl": "latest",
     "node-uuid": "^1.4.8",
     "nodemailer": "latest",
-    "oracledb": "^4.2.0",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "passport-localapikey-update": "^0.5.0",
@@ -55,7 +54,6 @@
     "serve-favicon": "~2.4.2",
     "slack": "latest",
     "socket.io": "^2.0.2",
-    "sqlite3": "~4.0.2",
     "systemjs": "^0.20.13",
     "telegram-bot-api": "^1.2.2",
     "twit": "latest",
@@ -84,5 +82,9 @@
     "nyc": "^15.1.0",
     "passport-stub": "^1.1.1",
     "prettier": "^1.16.4"
+  },
+  "optionalDependencies": {
+    "oracledb": "^4.2.0",
+    "sqlite3": "~4.0.2"
   }
 }


### PR DESCRIPTION
# Reason
The packaces `sqlite3` and `oracledb` are causing a lot of trouble when trying to run `npm install` on a lot of machines. For devices with apple silicon chips, there are no pre-built packages available, and manually building them does require some advanced knowledge

# Measures
Moved `sqlite2` and `oracledb` from `depencies` to `optional-dependencies`.
npm tries to install these, but doesn't fail the entire installation process, if one of these packages fails to install.
To make sure that the user has all the packages he needs to, I added a script that checks presence of the dependencies needed for the selected database type and aborts the run, if they are missing.

# Tests
Tests did run fine, except for user logout route, which always fails on my machine.