### PR TITLE
Multiple Push-Targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.3.12 - TBD
 * Refresh alias automatically when single capcode alias is updated @geelongmicrosoldering
 * Fix CSS Layout of Buttons on mobile devices #513 @geelongmicrosoldering
+* Added support for multi-target push notifications in Pushover, Telegram and Prowl @eopo
 
 # 0.3.11e - 2022-01-19
 * [HOTFIX ] Downgrade installed version of multimon-ng @marshyonline

--- a/server/plugins/Prowl.js
+++ b/server/plugins/Prowl.js
@@ -12,7 +12,7 @@ function run(trigger, scope, data, config, callback) {
     return callback();
   }
 
-  const keys = _.map(pConf.group.split(/(,|;)/g), key => {
+  const keys = _.map(pConf.group.split(/[;,]/), key => {
     key.trim();
   }).join(',');
 

--- a/server/plugins/Prowl.json
+++ b/server/plugins/Prowl.json
@@ -44,7 +44,7 @@
         {
             "name": "group",
             "label": "User/Group API Key",
-            "description": "Prowl destination for messages",
+            "description": "Prowl destination for messages. You can enter mulitple keys seperated by comma or semicolon.",
             "type": "text",
             "required": true
         },

--- a/server/plugins/Pushover.js
+++ b/server/plugins/Pushover.js
@@ -1,58 +1,63 @@
-var push = require('pushover-notifications');
-var logger = require('../log');
+const Push = require('pushover-notifications');
+const _ = require('underscore');
+const logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
-    var pConf = data.pluginconf.Pushover;
-    if (pConf && pConf.enable) {
-        //ensure key has been entered before trying to push
-        if (pConf.group == 0 || pConf.group == '0' || !pConf.group) {
-          logger.main.error('Pushover: ' + data.address + ' No User/Group key set. Please enter User/Group Key.');
-            callback();
-          } else {
-            var p = new push({
-              user: pConf.group,
-              token: config.pushAPIKEY,
-            });
-
-            var pushSound;
-            if (pConf.sound) {
-              pushSound = pConf.sound.value;
-            }
-
-            var pushPri = 0; // default
-            if (pConf.priority) {
-              pushPri = pConf.priority.value;
-            }
-            
-            var msg = {
-              message: data.message,
-              title: data.agency+' - '+data.alias,
-              sound: pushSound,
-              priority: pushPri,
-              onerror: function(err) {
-                logger.main.error('Pushover:', err);
-                }
-            };
-
-            if (pushPri == 2 || pushPri == '2') {
-              //emergency message
-              msg.retry = 60;
-              msg.expire = 240;
-              logger.main.info("SENDING EMERGENCY PUSH NOTIFICATION")
-            }
-
-            p.send(msg, function (err, result) {
-              if (err) { logger.main.error('Pushover:' + err); }
-              logger.main.debug('Pushover:' + result);
-              callback();
-            });
-          }
-    } else {
-        callback();
+  const pConf = data.pluginconf.Pushover;
+  if (pConf && pConf.enable) {
+    // ensure key has been entered before trying to push
+    if (pConf.group === 0 || pConf.group === '0' || !pConf.group) {
+      logger.main.error(`Pushover: ${data.address} No User/Group key set. Please enter User/Group Key.`);
+      return callback();
     }
 
+    // Split the entered keys on comma or semicolon, trim any whitespace and
+    // join them back together to one string using a comma, since Pushover
+    // API does accept comma-seperated lists of keys.
+
+    const keys = _.map(pConf.group.split(/(,|;)/g), key => {
+      key.trim();
+    }).join(',');
+
+    const p = new Push({
+      user: keys,
+      token: config.pushAPIKEY,
+    });
+
+    const sound = pConf.sound?.value;
+    const priority = pConf.priority?.value || 0;
+    const timestamp = pConf.timestamp?.value ? data.timestamp : undefined;
+
+    const msg = {
+      message: data.message,
+      title: `${data.agency} - ${data.alias}`,
+      sound,
+      priority,
+      timestamp,
+      onerror(err) {
+        logger.main.error('Pushover:', err);
+      },
+    };
+
+    if (priority === 2 || priority === '2') {
+      // emergency message
+      msg.retry = 60;
+      msg.expire = 240;
+      logger.main.info('SENDING EMERGENCY PUSH NOTIFICATION');
+    }
+
+    p.send(msg, function(err, result) {
+      if (err) {
+        logger.main.error(`Pushover:${err}`);
+      }
+      logger.main.debug(`Pushover:${result}`);
+      callback();
+    });
+  } else {
+    callback();
+  }
 }
 
 module.exports = {
-    run: run
-}
+  run,
+};

--- a/server/plugins/Pushover.js
+++ b/server/plugins/Pushover.js
@@ -4,48 +4,59 @@ const logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
   const pConf = data.pluginconf.Pushover;
-  if (pConf && pConf.enable) {
-    // ensure key has been entered before trying to push
-    if (pConf.group === 0 || pConf.group === '0' || !pConf.group) {
-      logger.main.error(`Pushover: ${data.address} No User/Group key set. Please enter User/Group Key.`);
-      return callback();
-    }
+  if (!pConf?.enable) {
+    return callback();
+  }
+  // ensure key has been entered before trying to push
+  if (pConf.group === 0 || pConf.group === '0' || !pConf.group) {
+    logger.main.error(`Pushover: ${data.address} No User/Group key set. Please enter User/Group Key.`);
+    return callback();
+  }
 
-    // Split the entered keys on comma or semicolon, trim any whitespace and
-    // join them back together to one string using a comma, since Pushover
-    // API does accept comma-seperated lists of keys.
+  // Split the entered keys on comma or semicolon, trim any whitespace and
+  // join them back together to one string using a comma, since Pushover
+  // API does accept comma-seperated lists of keys.
 
-    const keys = _.map(pConf.group.split(/(,|;)/g), key => {
-      key.trim();
-    }).join(',');
+  const keys = _.chain(pConf.group.split(/[;,]/))
+    .map(key => key.trim())
+    .filter(entry => {
+      try {
+        return entry?.length();
+      } catch (e) {
+        return false;
+      }
+    })
+    .join(',');
 
-    const p = new Push({
-      user: keys,
-      token: config.pushAPIKEY,
-    });
+  logger.main.debug(`User keys: ${keys}`);
 
-    const sound = pConf.sound?.value;
-    const priority = pConf.priority?.value || 0;
-    const timestamp = pConf.timestamp?.value ? data.timestamp : undefined;
+  const p = new Push({
+    user: keys,
+    token: config.pushAPIKEY,
+  });
 
-    const msg = {
-      message: data.message,
-      title: `${data.agency} - ${data.alias}`,
-      sound,
-      priority,
-      timestamp,
-      onerror(err) {
-        logger.main.error('Pushover:', err);
-      },
-    };
+  const sound = pConf.sound?.value;
+  const priority = pConf.priority?.value || 0;
+  const timestamp = pConf.timestamp?.value ? data.timestamp : undefined;
 
-    if (priority === 2 || priority === '2') {
-      // emergency message
-      msg.retry = 60;
-      msg.expire = 240;
-      logger.main.info('SENDING EMERGENCY PUSH NOTIFICATION');
-    }
+  const msg = {
+    message: data.message,
+    title: `${data.agency} - ${data.alias}`,
+    sound,
+    priority,
+    timestamp,
+    onerror(err) {
+      logger.main.error('Pushover:', err);
+    },
+  };
 
+  if (priority === 2 || priority === '2') {
+    // emergency message
+    msg.retry = 60;
+    msg.expire = 240;
+    logger.main.info('SENDING EMERGENCY PUSH NOTIFICATION');
+  }
+  try {
     p.send(msg, function(err, result) {
       if (err) {
         logger.main.error(`Pushover:${err}`);
@@ -53,8 +64,8 @@ function run(trigger, scope, data, config, callback) {
       logger.main.debug(`Pushover:${result}`);
       callback();
     });
-  } else {
-    callback();
+  } catch (e) {
+    logger.main.error(`error: ${e.message}`);
   }
 }
 

--- a/server/plugins/Pushover.json
+++ b/server/plugins/Pushover.json
@@ -11,6 +11,12 @@
             "description": "Application key supplied by Pushover.",
             "type": "text",
             "required": true
+        },
+        {
+            "name": "useTimestamp",
+            "label": "Use Message Timestamp",
+            "description": "Wether the messages stored timestamp of reception should be displayed on the users's device, or if it should fall back to the time of the API call to pushover",
+            "type": "checkbox"
         }
     ],
     "aliasConfig": [ 
@@ -37,7 +43,7 @@
         {
             "name": "group",
             "label": "User/Group Key",
-            "description": "Pushover destination for messages",
+            "description": "Pushover destination for messages. You can provide multiple user or group keys by seperating them per comma or semicolon.",
             "type": "text",
             "required": true
         },

--- a/server/plugins/Telegram.js
+++ b/server/plugins/Telegram.js
@@ -20,7 +20,7 @@ function run(trigger, scope, data, config, callback) {
   }
 
   // Split chat IDs by comma or semicolon, trim whitespace, make array of it.
-  const chatIds = _.map(tConf.chat.split(/(,|;)/g), chatId => chatId.trim());
+  const chatIds = _.map(tConf.chat.split(/[;,]/), chatId => chatId.trim());
 
   // Notification formatted in Markdown for pretty notifications
   const notificationText = `*${data.agency} - ${data.alias}*\nMessage: ${data.message}`;

--- a/server/plugins/Telegram.js
+++ b/server/plugins/Telegram.js
@@ -1,39 +1,49 @@
-var telegram = require('telegram-bot-api');
-var util = require('util');
-var logger = require('../log');
+const Telegram = require('telegram-bot-api');
+const _ = require('underscore');
+const util = require('util');
+const logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
-    var tConf = data.pluginconf.Telegram;
-    if (tConf && tConf.enable) {
-        var telekey = config.teleAPIKEY;
-        var t = new telegram({
-          token: telekey
-        });
-        if (tConf.chat == 0 || !tConf.chat) {
-            logger.main.error('Telegram: ' + data.address + ' No ChatID key set. Please enter ChatID.');
-            callback();
-        } else {
-            //Notification formatted in Markdown for pretty notifications
-            var notificationText = `*${data.agency} - ${data.alias}*\n` + 
-                                    `Message: ${data.message}`;
-            
-            t.sendMessage({
-                chat_id: tConf.chat,
-                text: notificationText,
-                parse_mode: "Markdown"
-            }).then(function(data) {
-                logger.main.debug('Telegram: ' + util.inspect(data, false, null));
-                callback();
-            }).catch(function(err) {
-                logger.main.error('Telegram: ' + err);
-                callback();
-            });
-        }
-    } else {
-        callback();
-    }
+  const tConf = data.pluginconf?.Telegram;
+
+  if (!tConf.enbale) {
+    return callback();
+  }
+
+  const telegram = new Telegram({
+    token: config.teleAPIKEY,
+  });
+
+  if (tConf.chat === 0 || !tConf.chat) {
+    logger.main.error(`Telegram: ${data.address} No ChatID key set. Please enter ChatID.`);
+    return callback();
+  }
+
+  // Split chat IDs by comma or semicolon, trim whitespace, make array of it.
+  const chatIds = _.map(tConf.chat.split(/(,|;)/g), chatId => chatId.trim());
+
+  // Notification formatted in Markdown for pretty notifications
+  const notificationText = `*${data.agency} - ${data.alias}*\nMessage: ${data.message}`;
+
+  chatIds.forEach(chatId => {
+    sendMessage(chatId, notificationText, telegram);
+  });
+  callback();
+}
+
+async function sendMessage(chatId, text, telegram) {
+  const message = { chat_id: chatId, text };
+
+  if (chatId.length() < 0) return logger.main.error(`Telegram: Invalid chat ID ${chatId} was provided.`);
+
+  try {
+    const apiResponse = await telegram.sendMessage(message);
+    logger.main.debug(`Telegram: ${util.inspect(apiResponse, false, null)}`);
+  } catch (error) {
+    logger.main.error(`Telegram: Failed to send message: ${error.message}`);
+  }
 }
 
 module.exports = {
-    run: run
-}
+  run,
+};

--- a/server/plugins/Telegram.js
+++ b/server/plugins/Telegram.js
@@ -6,7 +6,7 @@ const logger = require('../log');
 function run(trigger, scope, data, config, callback) {
   const tConf = data.pluginconf?.Telegram;
 
-  if (!tConf.enbale) {
+  if (!tConf.enable) {
     return callback();
   }
 
@@ -20,7 +20,9 @@ function run(trigger, scope, data, config, callback) {
   }
 
   // Split chat IDs by comma or semicolon, trim whitespace, make array of it.
-  const chatIds = _.map(tConf.chat.split(/[;,]/), chatId => chatId.trim());
+  const chatIds = _.chain(tConf.chat.split(/[;,]/))
+    .map(chatId => chatId.trim())
+    .filter(chatId => chatId.length);
 
   // Notification formatted in Markdown for pretty notifications
   const notificationText = `*${data.agency} - ${data.alias}*\nMessage: ${data.message}`;
@@ -34,7 +36,7 @@ function run(trigger, scope, data, config, callback) {
 async function sendMessage(chatId, text, telegram) {
   const message = { chat_id: chatId, text };
 
-  if (chatId.length() < 0) return logger.main.error(`Telegram: Invalid chat ID ${chatId} was provided.`);
+  if (chatId.length < 0) return logger.main.error(`Telegram: Invalid chat ID ${chatId} was provided.`);
 
   try {
     const apiResponse = await telegram.sendMessage(message);

--- a/server/plugins/Telegram.json
+++ b/server/plugins/Telegram.json
@@ -23,7 +23,7 @@
         {
             "name": "chat",
             "label": "Chat ID",
-            "description": "Telegram chat ID to send to",
+            "description": "Telegram chat ID to send to. You can input multiple chats seperated by comma or semicolon.",
             "type": "text",
             "required": true
         }


### PR DESCRIPTION
# Description

Pushing messages of one alias to multiple targets was not possible and required making copies of source code to generate a second plugin instance.
This PR includes code for the plugins Pagermon, Prowl and Telegram that makes it possible, to send messages to multiple targets at once.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made