### PR TITLE
Add .DS_Store to gitignore for mac users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ server/sessions
 #coverage
 server/coverage/
 
+# macOS Spotlight
+**/.DS_Store


### PR DESCRIPTION
# Description

Added DS_Store files to gitignore so Mac users don't have to look after them.
DS_Store ist used by mac's spotlight search to mark, if a directory has been visited.

## Type of change

- Meta-Change, doesn't affect source code itself.