### PR TITLE
553 api inconsistency regarding timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#TBA
+* Standardize code datetime and timestamp variables to timestamp and add backwards compatibility#553 @eopo
+
 # 0.3.12a - 2022-12-23
 * Revert #531 due to ongoing issues with crashes and 500 errors. @Danrw
  

--- a/client/reader.js
+++ b/client/reader.js
@@ -66,7 +66,7 @@ rl.on('line', (line) => {
     //console.log(`Received: ${line.trim()}`);
     var time = moment().format("YYYY-MM-DD HH:mm:ss");
     var timeString = '';
-    var datetime = moment().unix();
+    var timestamp = moment().unix();
     var address;
     var message;
     var trimMessage;
@@ -83,13 +83,13 @@ rl.on('line', (line) => {
                 if (message.match(/\d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/)) {
                     timeString = message.match(/\d+ \w+ \d+ \d{2}:\d{2}:\d{2}/)[0];
                     if (moment(timeString, 'DD MMMM YYYY HH:mm:ss').isValid()) {
-                        datetime = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
+                        timestamp = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
                         message = message.replace(/\d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/, '');
                     }
                 } else if (message.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)) {
                     timeString = message.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)[0];
                     if (moment(timeString).isValid()) {
-                        datetime = moment(timeString).unix();
+                        timestamp = moment(timeString).unix();
                         message = message.replace(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/, '');
                     }
                 }
@@ -108,12 +108,12 @@ rl.on('line', (line) => {
             if (line.match(/FLEX[:|] ?\d{2} \w+ \d{4} \d{2}:\d{2}:\d{2}/)) {
                 timeString = line.match(/\d+ \w+ \d+ \d{2}:\d{2}:\d{2}/)[0];
                 if (moment(timeString, 'DD MMMM YYYY HH:mm:ss').isValid()) {
-                    datetime = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
+                    timestamp = moment(timeString, 'DD MMMM YYYY HH:mm:ss').unix();
                 }
             } else if (line.match(/FLEX[:|] ?\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)) {
                 timeString = line.match(/\d+-\d+-\d+ \d{2}:\d{2}:\d{2}/)[0];
                 if (moment(timeString).isValid()) {
-                    datetime = moment(timeString).unix();
+                    timestamp = moment(timeString).unix();
                 }
             }
         }
@@ -167,7 +167,7 @@ rl.on('line', (line) => {
     var form = {
       address: padAddress,
       message: trimMessage,
-      datetime: datetime,
+      timestamp: timestamp,
       source: identifier
     };
     sendPage(form, 0);

--- a/server/plugins/MessageRepeat.js
+++ b/server/plugins/MessageRepeat.js
@@ -4,6 +4,7 @@
  */
 
 const axios = require('axios').default;
+const _ = require('underscore');
 var logger = require('../log')
 
 function run (trigger, scope, data, config, callback) {
@@ -22,13 +23,8 @@ function run (trigger, scope, data, config, callback) {
     }
 
     if (do_not_forward == false){
-      var message = {
-        address: data.address,
-        message: data.message,
-        source: data.source,
-        datetime: data.datetime,
-        UUID: config.repeatUUID,
-      };
+      const message = _.pick(data, ['address', 'message', 'source', 'timestamp']);
+      message.UUID = config.repeatUUID;
 
       logger.main.debug('MessageRepeat: Sending to ' + config.repeatURI + ': ' + JSON.stringify(message));
 

--- a/server/plugins/README.md
+++ b/server/plugins/README.md
@@ -146,7 +146,7 @@ On a `before` plugin, the `data` object has not yet been through alias matching,
 ```javascript
 { address: '8120000',
   message: 'Tue 20 Nov 2018 11:11:29 AEDT Test message, disregard',
-  datetime: '1542672689',
+  timestamp: '1542672689',
   source: 'TEST',
   pluginData: {} }
 ```

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -130,6 +130,8 @@ router.route('/messages')
             .then(rows => {
               rowCount = rows.length
               for (row of rows) {
+                row.datetime = row.timestamp // Copy timestamp to datetime  for backwards compatibilty
+
                 //outRow = JSON.parse(newrow);
                 if (HideCapcode) {
                   if (!req.isAuthenticated() || (req.isAuthenticated() && req.user.role == 'user')) {
@@ -138,6 +140,7 @@ router.route('/messages')
                       "message": row.message,
                       "source": row.source,
                       "timestamp": row.timestamp,
+                      "datetime": row.datetime,
                       "alias_id": row.alias_id,
                       "alias": row.alias,
                       "agency": row.agency,
@@ -185,14 +188,16 @@ router.route('/messages')
 
       if (filterDupes) {
         // this is a bad solution and tech debt that will bite us in the ass if we ever go HA, but that's a problem for future me and that guy's a dick
-        var datetime = data.datetime || 1;
-        var timeDiff = datetime - dupeTime;
+
+        var timestamp = data.timestamp || data.datetime || 1;
+
+        var timeDiff = timestamp - dupeTime;
         // if duplicate filtering is enabled, we want to populate the message buffer and check for duplicates within the limits
         var matches = _.where(msgBuffer, { message: data.message, address: data.address });
         if (matches.length > 0) {
           if (dupeTime != 0) {
             // search the matching messages and see if any match the time constrain
-            var timeFind = _.find(matches, function (msg) { return msg.datetime > timeDiff; });
+            var timeFind = _.find(matches, function (msg) { return msg.timestamp > timeDiff; });
             if (timeFind) {
               logger.main.info(util.format('Ignoring duplicate: %o', data.message));
               res.status(200);
@@ -213,8 +218,16 @@ router.route('/messages')
         if (msgBuffer.length > dupeArrayLimit) {
           msgBuffer.shift();
         }
-        msgBuffer.push({ message: data.message, datetime: data.datetime, address: data.address });
+        msgBuffer.push(_.pick(data,['message', 'timestamp', 'address']));
       }
+
+        if (data.timestamp)
+          var timestamp = data.timestamp;
+        else if (data.datetime) {
+          logger.main.warn(`An incoming message from ${data.source || 'an unknown source' } contains the timestamp as field 'datetime'. Update the message source to use the variable 'timestamp' instead!`);
+          var timestamp = data.datetime;
+        } else 
+          var timestamp = 1;
 
       // send data to pluginHandler before proceeding
       logger.main.debug('beforeMessage start');
@@ -232,8 +245,7 @@ router.route('/messages')
         }
         var address = data.address || '0000000';
         var message = data.message || 'null';
-        var datetime = data.datetime || 1;
-        var timeDiff = datetime - dupeTime;
+        var timeDiff = timestamp - dupeTime;
         var source = data.source || 'UNK';
         db.from('messages')
           .select('*')
@@ -320,7 +332,7 @@ router.route('/messages')
                   }
 
                   if (insert == true) {
-                    var insertmsg = { address: address, message: message, timestamp: datetime, source: source, alias_id: alias_id }
+                    var insertmsg = { address, message, timestamp, source, alias_id }
                     db('messages').insert(insertmsg).returning('id')
                       .then((result) => {
                         // emit the full message
@@ -356,6 +368,9 @@ router.route('/messages')
                               // send data to pluginHandler after processing
                               row.pluginData = data.pluginData;
 
+                              // Copy timestamp to datetime for backwards compatibility.
+                              row.datetime = row.timestamp;
+
                               if (row.pluginconf) {
                                 row.pluginconf = parseJSON(row.pluginconf);
                               } else {
@@ -380,6 +395,7 @@ router.route('/messages')
                                           "message": row.message,
                                           "source": row.source,
                                           "timestamp": row.timestamp,
+                                          "datetime": row.timestamp, // Copy timestamp to datetime for backwards compatibility
                                           "alias_id": row.alias_id,
                                           "alias": row.alias,
                                           "agency": row.agency,
@@ -398,6 +414,7 @@ router.route('/messages')
                                           "message": row.message,
                                           "source": row.source,
                                           "timestamp": row.timestamp,
+                                          "datetime": row.timestamp, // Copy timestamp to datetime for backwards compatibility
                                           "alias_id": row.alias_id,
                                           "alias": row.alias,
                                           "agency": row.agency,
@@ -415,6 +432,7 @@ router.route('/messages')
                                       "message": row.message,
                                       "source": row.source,
                                       "timestamp": row.timestamp,
+                                      "datetime": row.timestamp, // Copy timestamp to datetime for backwards compatibility
                                       "alias_id": row.alias_id,
                                       "alias": row.alias,
                                       "agency": row.agency,
@@ -499,6 +517,7 @@ router.route('/messages/:id')
               "id": row[0].id,
               "message": row[0].message,
               "source": row[0].source,
+              "datetime": row[0].timestamp, // Add datetime for backwards compatibility
               "timestamp": row[0].timestamp,
               "alias_id": row[0].alias_id,
               "alias": row[0].alias,
@@ -613,12 +632,14 @@ router.route('/messageSearch')
       .then((rows) => {
         if (rows) {
           for (row of rows) {
+            row.datetime = row.timestamp // Copy timestamp to datetime for backwards compatibility
             if (HideCapcode) {
               if (!req.isAuthenticated() || (req.isAuthenticated() && req.user.role == 'user')) {
                 row = {
                   "id": row.id,
                   "message": row.message,
                   "source": row.source,
+                  "datetime": row.datetime,
                   "timestamp": row.timestamp,
                   "alias_id": row.alias_id,
                   "alias": row.alias,

--- a/server/test/routes.api.capcodes.test.js
+++ b/server/test/routes.api.capcodes.test.js
@@ -6,8 +6,6 @@ const moment = require('moment');
 const should = chai.should();
 const chaiHttp = require('chai-http');
 
-const datetime = moment().unix();
-
 chai.use(chaiHttp);
 
 const confFile = './config/config.json';

--- a/server/test/routes.api.messages.test.js
+++ b/server/test/routes.api.messages.test.js
@@ -6,7 +6,7 @@ const moment = require('moment');
 const should = chai.should();
 const chaiHttp = require('chai-http');
 
-const datetime = moment().unix();
+const timestamp = moment().unix();
 
 chai.use(chaiHttp);
 
@@ -47,7 +47,7 @@ describe('POST /api/messages', () => {
                         .send({
                                 address: '000000',
                                 message: '!@#$%^& (This is a test message. 1a2b3c4d5e6e7f) !@#$%^&',
-                                datetime,
+                                timestamp,
                                 source: 'CI-Test',
                         })
                         .end((err, res) => {
@@ -69,7 +69,7 @@ describe('POST /api/messages', () => {
                         .send({
                                 address: '000000',
                                 message: '!@#$%^& (This is a test message. 1a2b3c4d5e6e7f) !@#$%^&',
-                                datetime,
+                                timestamp,
                                 source: 'CI-Test',
                         })
                         .end((err, res) => {

--- a/server/themes/default/views/index.ejs
+++ b/server/themes/default/views/index.ejs
@@ -104,7 +104,7 @@
         <tbody>
           <tr ng-repeat="message in messages | filter: search">
             <td class="shrink noMobile noSmall">{{message.date}}</td>
-            <td class="shrink">{{message.timestamp}}</td>
+            <td class="shrink">{{message.time}}</td>
             <% if (!hidesource || (login && user.role == 'admin')) { %>
               <td class="shrink noMobile noSmall clickable-td" uib-popover-template="'templates/popover.html'" popover-append-to-body=true ng-click="popoverEl = 'source'" popover-trigger="'outsideClick'" style="background-color: {{message.color || 'grey'}}; text-align: center;">
                 <span class="small" style="color: white; font-family: monospace;"><strong>{{message.source}}</strong></span>
@@ -370,9 +370,9 @@
           // only bother getting the new message if we're on page 1
           if ($scope.init.currentPage === 1) {
             console.log('New Message ID: '+message.id + ' currentPage: '+$scope.init.currentPage);
-            var datetime = moment.unix(message.timestamp);
-            message.date = datetime.format("YYYY-MM-DD");
-            message.timestamp = datetime.format("HH:mm");
+            var timestamp = moment.unix(message.timestamp);
+            message.date = timestamp.format("YYYY-MM-DD");
+            message.time = timestamp.format("HH:mm");
           //  result.padAddress = $scope.padDigits(result.address,7);
           //  result.aliasMatch = result['MAX(capcodes.address)'];
             if ($routeParams.q || $routeParams.agency || $routeParams.address) {
@@ -494,9 +494,9 @@
                     results.init.pages = pages;
                     $scope.init = results.init;
                     angular.forEach(results.messages, function (result) {
-                      var datetime = moment.unix(result.timestamp);
-                      result.date = datetime.format("YYYY-MM-DD");
-                      result.timestamp = datetime.format("HH:mm");
+                      var timestamp = moment.unix(result.timestamp);
+                      result.date = timestamp.format("YYYY-MM-DD");
+                      result.time = timestamp.format("HH:mm");
                       result.message = $scope.htmlEntities(result.message);
                       //  result.padAddress = $scope.padDigits(result.address,7);
                       //    result.aliasMatch = result['MAX(capcodes.address)'];
@@ -536,9 +536,9 @@
                     results.init.pages = pages;
                     $scope.init = results.init;
                     angular.forEach(results.messages, function (result) {
-                      var datetime = moment.unix(result.timestamp);
-                      result.date = datetime.format("YYYY-MM-DD");
-                      result.timestamp = datetime.format("HH:mm");
+                      var timestamp = moment.unix(result.timestamp);
+                      result.date = timestamp.format("YYYY-MM-DD");
+                      result.time = timestamp.format("HH:mm");
                       result.message = $scope.htmlEntities(result.message);
                       //  result.padAddress = $scope.padDigits(result.address,7);
                       //  result.aliasMatch = result['MAX(capcodes.address)'];


### PR DESCRIPTION
# Description

The API used to use the names `timestamp` and `datetime` for the same thing, the moment a message was received. This differed in incoming and outgoing messages as well as the ejs views and the MessageRepeat plugin. The database always used the name timestamp, and converting was done inside API request handlers and view rendering.
Everything is now using the name `timestamp` per default. Every API response and the message repeat plugin does include the copied `timestamp` value aliases as `datetime` in order to not introduce a breaking change.
Sending a message POST request to the API does generate a deprecation warning in the server log, so the administrator is warned that some message source does use the `datetime` variable and should be updated to `timestamp`.

Fixes #553, kinda addresses parts of #525 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Ran test suite
Sent and received test messages on local testing instance

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



