### PR TITLE
Hide Capcode in Small Screen mode

### DIFF
--- a/server/themes/default/views/index.ejs
+++ b/server/themes/default/views/index.ejs
@@ -91,7 +91,7 @@
               <th class="noMobile noSmall" style="text-align: center;">Src</th>
             <% } %>
             <% if (!hidecapcode || (login && user.role == 'admin')) { %>
-              <th class="noMobile" style="text-align: center;">Capcode</th>
+              <th class="noMobile" style="text-align: center;"><span class="noSmall">Capcode</span></th>
             <% } %>
             <th class="noMobile noSmall"></th>
             <th class="noMobile noSmall"></th>


### PR DESCRIPTION
# Description

Added a SPAN to the Capcode Header line to hide the CapCode wording when in Small Screen mode without altering any other display functionality

Fixes #582 


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Confirmed Full Screen mode no changes
![image](https://github.com/pagermon/pagermon/assets/28804763/a4921788-f7c5-4579-b00b-e51ff68eca1c)
- [x] Confirmed Small Screen mode no longer has Capcode header displayed (and an additional column created)
![image](https://github.com/pagermon/pagermon/assets/28804763/c42e2b48-db76-494d-9363-ed5357db4059)
- [x] confirmed Mobile Screen mode has no changes
![Screenshot_20231126-004012](https://github.com/pagermon/pagermon/assets/28804763/75fc9224-6968-49b3-9668-df9453b45e14)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- NA I have commented my code, particularly in hard-to-understand areas
- NA I have updated changelog.md with changes made



