### PR TITLE
MQTT plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix non matching messages when filtering alias #543 @geelongmicrosoldering
 * Fix [ERR_HTTP_HEADERS_SENT] error in /api route by combining res.status and res.send @nic-hanna
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
+* Add MQTT Plugin #584 @ChoffaH
 
 # 0.3.13 - 2023-09-04
 * Add Config option to fix FA icon's no longer loading. @marshyonline

--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,7 @@
     "knex": "^2.5.1",
     "moment": "^2.26.0",
     "morgan": "~1.9.1",
+    "mqtt": "^4.3.7",
     "mysql": "^2.16.0",
     "nconf": "^0.12.0",
     "node-prowl": "latest",

--- a/server/plugins/MQTT.js
+++ b/server/plugins/MQTT.js
@@ -1,14 +1,24 @@
 const mqtt = require('mqtt');
+const logger = require('../log');
 
 function run(trigger, scope, data, config, callback) {
     const mConf = data.pluginconf.MQTT;
     if (mConf && mConf.enable) {
+        logger.main.debug('MQTT: connecting to MQTT server');
+
         const client = mqtt.connect(config.URL, {
             username: config.username,
             password: config.password,
         });
 
+        client.on('error', error => {
+            logger.main.error(`MQTT: failed to connect to MQTT server: ${error}`);
+            callback();
+        });
+
         client.on('connect', () => {
+            logger.main.debug('MQTT: connected to MQTT server');
+
             const baseTopic = config.baseTopic || 'pagermon';
             const alias = data.alias;
             const aliasId = data.alias_id;
@@ -25,13 +35,15 @@ function run(trigger, scope, data, config, callback) {
                 color: data.color,
             };
 
+            logger.main.debug('MQTT: publishing messages');
+
             // Publish latest message
             client.publish(`${baseTopic}`, JSON.stringify(stateData));
 
             // Publish latest message per alias
             client.publish(`${baseTopic}/${aliasId}`, JSON.stringify(stateData));
 
-            if (config.homeAssistant === 1) {
+            if (config.homeAssistant === true) {
                 // If home assistant integration activated, send discovery message
                 const discoveryTopic = config.discoveryTopic || 'homeassistant';
                 const device = {
@@ -39,6 +51,8 @@ function run(trigger, scope, data, config, callback) {
                     model: 'PagerMon',
                     name: 'PagerMon',
                 };
+
+                logger.main.debug('MQTT: publishing home assistant discovery messages');
 
                 // Configuration for latest message
                 client.publish(
@@ -68,6 +82,8 @@ function run(trigger, scope, data, config, callback) {
                     { retain: true }
                 );
             }
+
+            logger.main.debug('MQTT: messages published');
 
             client.end();
             callback();

--- a/server/plugins/MQTT.js
+++ b/server/plugins/MQTT.js
@@ -20,6 +20,7 @@ function run(trigger, scope, data, config, callback) {
             logger.main.debug('MQTT: connected to MQTT server');
 
             const baseTopic = config.baseTopic || 'pagermon';
+            const retainBaseTopic = config.retainBaseTopic === true;
             const alias = data.alias;
             const aliasId = data.alias_id;
             const stateData = {
@@ -38,12 +39,12 @@ function run(trigger, scope, data, config, callback) {
             logger.main.debug('MQTT: publishing messages');
 
             // Publish latest message
-            client.publish(`${baseTopic}`, JSON.stringify(stateData));
+            client.publish(`${baseTopic}`, JSON.stringify(stateData), { retain: retainBaseTopic });
 
             // Publish latest message per alias
-            client.publish(`${baseTopic}/${aliasId}`, JSON.stringify(stateData));
+            client.publish(`${baseTopic}/${aliasId}`, JSON.stringify(stateData), { retain: retainBaseTopic });
 
-            if (config.homeAssistant === true) {
+            if (config.enableHomeAssistant === true) {
                 // If home assistant integration activated, send discovery message
                 const discoveryTopic = config.discoveryTopic || 'homeassistant';
                 const device = {

--- a/server/plugins/MQTT.js
+++ b/server/plugins/MQTT.js
@@ -1,0 +1,82 @@
+const mqtt = require('mqtt');
+
+function run(trigger, scope, data, config, callback) {
+    const mConf = data.pluginconf.MQTT;
+    if (mConf && mConf.enable) {
+        const client = mqtt.connect(config.URL, {
+            username: config.username,
+            password: config.password,
+        });
+
+        client.on('connect', () => {
+            const baseTopic = config.baseTopic || 'pagermon';
+            const alias = data.alias;
+            const aliasId = data.alias_id;
+            const stateData = {
+                id: data.id,
+                address: data.address,
+                message: data.message,
+                source: data.source,
+                timestamp: data.timestamp,
+                alias: data.alias,
+                alias_id: data.alias_id,
+                agency: data.agency,
+                icon: data.icon,
+                color: data.color,
+            };
+
+            // Publish latest message
+            client.publish(`${baseTopic}`, JSON.stringify(stateData));
+
+            // Publish latest message per alias
+            client.publish(`${baseTopic}/${aliasId}`, JSON.stringify(stateData));
+
+            if (config.homeAssistant === 1) {
+                // If home assistant integration activated, send discovery message
+                const discoveryTopic = config.discoveryTopic || 'homeassistant';
+                const device = {
+                    identifiers: 'pagermon',
+                    model: 'PagerMon',
+                    name: 'PagerMon',
+                };
+
+                // Configuration for latest message
+                client.publish(
+                    `${discoveryTopic}/sensor/pagermon/latest_message/config`,
+                    JSON.stringify({
+                        device,
+                        state_topic: `${baseTopic}`,
+                        json_attributes_topic: `${baseTopic}`,
+                        name: `Latest message`,
+                        unique_id: `latest_message`,
+                        value_template: `{{ value_json.message }}`,
+                    }),
+                    { retain: true }
+                );
+
+                // Configuration for latest message per alias
+                client.publish(
+                    `${discoveryTopic}/sensor/pagermon/${aliasId}_message/config`,
+                    JSON.stringify({
+                        device,
+                        state_topic: `${baseTopic}/${aliasId}`,
+                        json_attributes_topic: `${baseTopic}/${aliasId}`,
+                        name: `${alias} message`,
+                        unique_id: `${aliasId}_message`,
+                        value_template: `{{ value_json.message }}`,
+                    }),
+                    { retain: true }
+                );
+            }
+
+            client.end();
+            callback();
+        });
+    } else {
+        callback();
+    }
+}
+
+module.exports = {
+    run,
+};

--- a/server/plugins/MQTT.json
+++ b/server/plugins/MQTT.json
@@ -19,6 +19,12 @@
             "type": "text"
         },
         {
+            "name": "retainBaseTopic",
+            "label": "Retain messages",
+            "description": "Enable the retain flag on base topic messages. This is prefered when using with home assistant as otherwise messages will be unknown after a restart",
+            "type": "checkbox"
+        },
+        {
             "name": "username",
             "label": "Username",
             "description": "MQTT server authentication user",
@@ -31,10 +37,10 @@
             "type": "password"
         },
         {
-        "name": "homeAssistant",
-        "label": "Home Assistant integration",
-        "description": "Enable Home Assistant integration with mqtt discovery",
-        "type": "checkbox"
+            "name": "enableHomeAssistant",
+            "label": "Home Assistant integration",
+            "description": "Enable Home Assistant integration with MQTT discovery",
+            "type": "checkbox"
         },
         {
             "name": "discoveryTopic",

--- a/server/plugins/MQTT.json
+++ b/server/plugins/MQTT.json
@@ -1,0 +1,54 @@
+{
+    "name": "MQTT",
+    "description": "Send messages to an MQTT server",
+    "disable": false,
+    "trigger": "message",
+    "scope": "after",
+    "config": [
+        {
+            "name": "URL",
+            "label": "MQTT server URL",
+            "description": "MQTT server URL (use mqtts:// for SSL/TLS connection)",
+            "type": "text",
+            "required": true
+        },
+        {
+            "name": "baseTopic",
+            "label": "MQTT base topic",
+            "description": "MQTT base topic for PagerMon MQTT messages (defaults to \"pagermon\")",
+            "type": "text"
+        },
+        {
+            "name": "username",
+            "label": "Username",
+            "description": "MQTT server authentication user",
+            "type": "text"
+        },
+        {
+            "name": "password",
+            "label": "Password",
+            "description": "MQTT server authentication password",
+            "type": "password"
+        },
+        {
+        "name": "homeAssistant",
+        "label": "Home Assistant integration",
+        "description": "Enable Home Assistant integration with mqtt discovery",
+        "type": "checkbox"
+        },
+        {
+            "name": "discoveryTopic",
+            "label": "Homeassistant discovery topic",
+            "description": "Homeassistant discovery topic (defaults to \"homeassistant\")",
+            "type": "text"
+        }
+    ],
+    "aliasConfig": [ 
+        {
+            "name": "enable",
+            "label": "Enable",
+            "description": "Enable sending messages that match this alias via MQTT",
+            "type": "checkbox"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

A plugin that sends messages to an configurable MQTT broker. It requires the "mqtt" node package, added to package.json.
It also includes optional support for Home Assistant auto discovery via MQTT.

Fixes #561 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested this locally on my server for a couple of weeks and it's sending messages. Don't know how to test this more?

# Checklist:

- [x] My code follows the style guidelines of this project 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



