### PR TITLE
Feature: Filter for missing alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
 * Add MQTT Plugin #584 @ChoffaH
 * Hide Capcode in Small Screen mode Hide Capcode in Small Screen mode #583 @bullseye555
+* Add filtering for messages without alias #594 @eopo
   
-
 # 0.3.13 - 2023-09-04
 * Add Config option to fix FA icon's no longer loading. @marshyonline
 

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -1,112 +1,129 @@
-
-exports.seed = function(db, Promise) {
-  // Deletes ALL existing entries
-  return db('messages').del() // Deletes ALL existing entries
-    .then(function() { // Inserts seed entries one by one in series
-      return db('messages').insert({
-        address: '1234567',
-        message: 'This is a Test Message to Address 1234567',
-        source: 'Client 1',
-        timestamp: '1529487722'
-      });
-    }).then(function () {
-      return db('messages').insert({
-        address: '1234567',
-        message: 'This is another Test Message to Address 1234567',
-        source: 'Client 2',
-        timestamp: '1529488007'
-      });
-    }).then(function () {
-      return db('messages').insert({
-        address: '1234568',
-        message: 'This is a Test Message to Address 1234568',
-        source: 'Client 1',
-        timestamp: '1529489509'
-      });
-    }).then(function () {
-      return db('messages').insert({
-        address: '1234569',
-        message: 'This is a Test Message to Address 1234569',
-        source: 'Client 3',
-        timestamp: '1529495672'
-      });
-    }).then(function () {
-      return db('messages').insert({
-        address: '1234570',
-        message: 'This is a Test Message to Address 1234570',
-        source: 'Client 4',
-        timestamp: '1529494321'
-      });
-    }).then(function () {
-      return db('capcodes').del()
-    }).then(function () {
-      return db('capcodes').insert({
-        address: '1234567',
-        alias: 'Fire Brigade',
-        agency: 'FIRE',
-        icon: 'fire',
-        color: 'red',
-        ignore: '0',
-      });
-    }).then(function () {
-      return db('capcodes').insert({
-        address: '1234568',
-        alias: 'Ambulance 1',
-        agency: 'AMBULANCE',
-        icon: 'ambulance',
-        color: 'green',
-        ignore: '0',
-      });
-    }).then(function () {
-      return db('capcodes').insert({
-        address: '1234569',
-        alias: 'Police Station',
-        agency: 'POLICE',
-        icon: 'gavel',
-        color: 'blue',
-        ignore: '0',
-      });
-    }).then(function () {
-      return db('capcodes').insert({
-        address: '1234570',
-        alias: 'Ignore Capcode',
-        agency: 'IGNORE',
-        icon: '',
-        color: '',
-        ignore: '1',
-      });
-    }).then(function () {
-      return db('users').del()
-    }).then(function () {
-      return db('users').insert({
-        givenname: 'Active',
-        surname: 'User',
-        username: 'useractive',
-        password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
-        email: 'none1@none.com',
-        role: 'user',
-        status: 'active',
-      });
-    }).then(function () {
-      return db('users').insert({
-        givenname: 'Active',
-        surname: 'Admin',
-        username: 'adminactive',
-        password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
-        email: 'none2@none.com',
-        role: 'admin',
-        status: 'active',
-      });
-    }).then(function () {
-      return db('users').insert({
-        givenname: 'Disabled',
-        surname: 'Admin',
-        username: 'admindisabled',
-        password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
-        email: 'none3@none.com',
-        role: 'admin',
-        status: 'disabled',
-      });
-    })
+exports.seed = function (db, Promise) {
+        // Deletes ALL existing entries
+        return db('messages')
+                .del() // Deletes ALL existing entries
+                .then(() => db('capcodes').del())
+                .then(() =>
+                        db('capcodes').insert({
+                                address: '1234567',
+                                alias: 'Fire Brigade',
+                                agency: 'FIRE',
+                                icon: 'fire',
+                                color: 'red',
+                                ignore: '0',
+                        })
+                )
+                .then(() =>
+                        db('capcodes').insert({
+                                address: '1234568',
+                                alias: 'Ambulance 1',
+                                agency: 'AMBULANCE',
+                                icon: 'ambulance',
+                                color: 'green',
+                                ignore: '0',
+                        })
+                )
+                .then(() =>
+                        db('capcodes').insert({
+                                address: '1234569',
+                                alias: 'Police Station',
+                                agency: 'POLICE',
+                                icon: 'gavel',
+                                color: 'blue',
+                                ignore: '0',
+                        })
+                )
+                .then(() =>
+                        db('capcodes').insert({
+                                address: '1234570',
+                                alias: 'Ignore Capcode',
+                                agency: 'IGNORE',
+                                icon: '',
+                                color: '',
+                                ignore: '1',
+                        })
+                )
+                .then(() =>
+                        // Inserts seed entries one by one in series
+                        db('messages').insert({
+                                address: '1234567',
+                                message: 'This is a Test Message to Address 1234567',
+                                source: 'Client 1',
+                                timestamp: '1529487722',
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234567',
+                                message: 'This is another Test Message to Address 1234567',
+                                source: 'Client 2',
+                                timestamp: '1529488007',
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234568',
+                                message: 'This is a Test Message to Address 1234568',
+                                source: 'Client 1',
+                                timestamp: '1529489509',
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234569',
+                                message: 'This is a Test Message to Address 1234569',
+                                source: 'Client 3',
+                                timestamp: '1529495672',
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234570',
+                                message: 'This is a Test Message to Address 1234570',
+                                source: 'Client 4',
+                                timestamp: '1529494321',
+                        })
+                )
+                .then(() =>
+                        db('messages').insert({
+                                address: '1234572',
+                                message: 'This is a Test Message to non-stored Address 1234572',
+                                source: 'Client 4',
+                                timestamp: '1529494321',
+                        })
+                )
+                .then(() => db('users').del())
+                .then(() =>
+                        db('users').insert({
+                                givenname: 'Active',
+                                surname: 'User',
+                                username: 'useractive',
+                                password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
+                                email: 'none1@none.com',
+                                role: 'user',
+                                status: 'active',
+                        })
+                )
+                .then(() =>
+                        db('users').insert({
+                                givenname: 'Active',
+                                surname: 'Admin',
+                                username: 'adminactive',
+                                password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
+                                email: 'none2@none.com',
+                                role: 'admin',
+                                status: 'active',
+                        })
+                )
+                .then(() =>
+                        db('users').insert({
+                                givenname: 'Disabled',
+                                surname: 'Admin',
+                                username: 'admindisabled',
+                                password: '$2a$08$De/aXnQkZIEbQ9p8J22tHuzLltqIbsAxE2CGgRMPLaaIwwHmVrpsu',
+                                email: 'none3@none.com',
+                                role: 'admin',
+                                status: 'disabled',
+                        })
+                );
 };
-

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -44,6 +44,16 @@ exports.seed = function (db, Promise) {
                         })
                 )
                 .then(() =>
+                        db('capcodes').insert({
+                                address: '12345790',
+                                alias: 'Capcode with no messages',
+                                agency: 'EMPTY',
+                                icon: '',
+                                color: '',
+                                ignore: '1',
+                        })
+                )
+                .then(() =>
                         // Inserts seed entries one by one in series
                         db('messages').insert({
                                 address: '1234567',

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -50,7 +50,7 @@ exports.seed = function (db, Promise) {
                                 agency: 'EMPTY',
                                 icon: '',
                                 color: '',
-                                ignore: '1',
+                                ignore: '0',
                         })
                 )
                 .then(() =>
@@ -60,6 +60,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is a Test Message to Address 1234567',
                                 source: 'Client 1',
                                 timestamp: '1529487722',
+                                alias_id: '1'
                         })
                 )
                 .then(() =>
@@ -68,6 +69,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is another Test Message to Address 1234567',
                                 source: 'Client 2',
                                 timestamp: '1529488007',
+                                alias_id: '1'
                         })
                 )
                 .then(() =>
@@ -76,6 +78,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is a Test Message to Address 1234568',
                                 source: 'Client 1',
                                 timestamp: '1529489509',
+                                alias_id: '2'
                         })
                 )
                 .then(() =>
@@ -84,6 +87,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is a Test Message to Address 1234569',
                                 source: 'Client 3',
                                 timestamp: '1529495672',
+                                alias_id: '3'
                         })
                 )
                 .then(() =>
@@ -92,6 +96,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is a Test Message to Address 1234570',
                                 source: 'Client 4',
                                 timestamp: '1529494321',
+                                alias_id: '4'
                         })
                 )
                 .then(() =>
@@ -100,6 +105,7 @@ exports.seed = function (db, Promise) {
                                 message: 'This is a Test Message to non-stored Address 1234572',
                                 source: 'Client 5',
                                 timestamp: '1529494322',
+                                alias_id: undefined
                         })
                 )
                 .then(() => db('users').del())

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -98,8 +98,8 @@ exports.seed = function (db, Promise) {
                         db('messages').insert({
                                 address: '1234572',
                                 message: 'This is a Test Message to non-stored Address 1234572',
-                                source: 'Client 4',
-                                timestamp: '1529494321',
+                                source: 'Client 5',
+                                timestamp: '1529494322',
                         })
                 )
                 .then(() => db('users').del())

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -620,8 +620,12 @@ router.route('/messageSearch')
             qb.whereIn('messages.alias_id', function (qb2) {
               qb2.select('id').from('capcodes').where('agency', agency).where('ignore', 0);
           })
-          if (alias != '')
-            qb.where('messages.alias_id',alias);
+          if (alias != '') {
+            if (alias === -1) 
+              qb.whereNull('messages.alias_id');
+            else
+              qb.where('messages.alias_id',alias);
+          }
         }
       }).orderBy('messages.timestamp', 'desc')
       .then((rows) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -621,7 +621,7 @@ router.route('/messageSearch')
               qb2.select('id').from('capcodes').where('agency', agency).where('ignore', 0);
           })
           if (alias != '') {
-            if (alias === -1) 
+            if (alias === '-1') 
               qb.whereNull('messages.alias_id');
             else
               qb.where('messages.alias_id',alias);

--- a/server/test/routes.api.capcodes.test.js
+++ b/server/test/routes.api.capcodes.test.js
@@ -28,753 +28,750 @@ beforeEach(() => db.migrate.rollback().then(() => db.migrate.latest().then(() =>
 afterEach(() => db.migrate.rollback().then(() => passportStub.logout()));
 
 describe('GET /api/capcodes', () => {
-    it('should return all capcodes when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return all capcodes when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodes')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('id');
+                                res.body[0].should.have.property('address');
+                                res.body[0].should.have.property('alias');
+                                res.body[0].should.have.property('agency');
+                                res.body[0].should.have.property('icon');
+                                res.body[0].should.have.property('color');
+                                res.body[0].should.have.property('pluginconf');
+                                res.body[0].should.have.property('ignore');
+                                res.body.length.should.eql(5);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('id')
-                res.body[0].should.have.property('address')
-                res.body[0].should.have.property('alias')
-                res.body[0].should.have.property('agency')
-                res.body[0].should.have.property('icon')
-                res.body[0].should.have.property('color')
-                res.body[0].should.have.property('pluginconf')
-                res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(4)
-                done();
-            });
-    });
-    it('should return all capcodes when api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('id')
-                res.body[0].should.have.property('address')
-                res.body[0].should.have.property('alias')
-                res.body[0].should.have.property('agency')
-                res.body[0].should.have.property('icon')
-                res.body[0].should.have.property('color')
-                res.body[0].should.have.property('pluginconf')
-                res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(4)
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return all capcodes when api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('id');
+                                res.body[0].should.have.property('address');
+                                res.body[0].should.have.property('alias');
+                                res.body[0].should.have.property('agency');
+                                res.body[0].should.have.property('icon');
+                                res.body[0].should.have.property('color');
+                                res.body[0].should.have.property('pluginconf');
+                                res.body[0].should.have.property('ignore');
+                                res.body.length.should.eql(5);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .get('/api/capcodes')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .get('/api/capcodes')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
-describe('POST /api/capcodes', () => {
-});
+describe('POST /api/capcodes', () => {});
 
 describe('GET /api/capcodes/:id', () => {
-    it('should return specific capcode when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return specific capcode when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/2')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql(2);
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('1234568');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('Ambulance 1');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('AMBULANCE');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('ambulance');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('green');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/2')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql(2)
-                res.body.should.have.property('address')
-                res.body.address.should.eql('1234568')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('Ambulance 1')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('AMBULANCE')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('ambulance')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('green')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return blank capcode when id is new when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return blank capcode when id is new when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/new')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql('');
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('question');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('black');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/new')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql('')
-                res.body.should.have.property('address')
-                res.body.address.should.eql('')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('question')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('black')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return specific capcode when api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/2')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql(2)
-                res.body.should.have.property('address')
-                res.body.address.should.eql('1234568')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('Ambulance 1')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('AMBULANCE')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('ambulance')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('green')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return blank capcode when id is new when api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/new')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql('')
-                res.body.should.have.property('address')
-                res.body.address.should.eql('')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('question')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('black')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return specific capcode when api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/2')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql(2);
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('1234568');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('Ambulance 1');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('AMBULANCE');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('ambulance');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('green');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/2')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .get('/api/capcodes/2')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/2')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return blank capcode when id is new when api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/new')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql('');
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('question');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('black');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
+        });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/2')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/2')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/2')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
-describe('POST /api/capcodes/:id', () => {
-});
+describe('POST /api/capcodes/:id', () => {});
 
 describe('DELETE /api/capcodes/:id', () => {
-    it('should delete a capcode when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should delete a capcode when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .delete('/api/capcodes/2')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.body.status.should.eql('ok');
+                                done();
+                        });
         });
-        chai.request(server)
-            .delete('/api/capcodes/2')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.body.status.should.eql('ok')
-                done();
-            });
-    });
-    it('should delete a capcode when api key is provided', done => {
-        chai.request(server)
-            .delete('/api/capcodes/2')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.body.status.should.eql('ok')
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should delete a capcode when api key is provided', (done) => {
+                chai.request(server)
+                        .delete('/api/capcodes/2')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.body.status.should.eql('ok');
+                                done();
+                        });
         });
-        chai.request(server)
-            .delete('/api/capcodes/2')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .delete('/api/capcodes/2')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .delete('/api/capcodes/2')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .delete('/api/capcodes/2')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .delete('/api/capcodes/2')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .delete('/api/capcodes/2')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
 describe('GET /api/capcodes/agency', () => {
-    it('should return all agencies when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return all agencies when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/agency')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('agency');
+                                res.body.length.should.eql(5);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/agency')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('agency')
-                res.body.length.should.eql(4)
-                done();
-            });
-    });
-    it('should return all capcodes when api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('agency')
-                res.body.length.should.eql(4)
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return all capcodes when api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('agency');
+                                res.body.length.should.eql(5);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/agency')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/agency')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
 describe('GET /api/capcodes/agency/:id', () => {
-    it('should return all capcodes with specific agency when logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return all capcodes with specific agency when logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/agency/FIRE')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('id');
+                                res.body[0].id.should.eql(1);
+                                res.body[0].should.have.property('address');
+                                res.body[0].address.should.eql('1234567');
+                                res.body[0].should.have.property('alias');
+                                res.body[0].alias.should.eql('Fire Brigade');
+                                res.body[0].should.have.property('agency');
+                                res.body[0].agency.should.eql('FIRE');
+                                res.body[0].should.have.property('icon');
+                                res.body[0].icon.should.eql('fire');
+                                res.body[0].should.have.property('color');
+                                res.body[0].color.should.eql('red');
+                                res.body[0].should.have.property('pluginconf');
+                                res.body[0].should.have.property('ignore');
+                                res.body[0].ignore.should.eql(0);
+                                res.body.length.should.eql(1);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/agency/FIRE')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('id')
-                res.body[0].id.should.eql(1)
-                res.body[0].should.have.property('address')
-                res.body[0].address.should.eql('1234567')
-                res.body[0].should.have.property('alias')
-                res.body[0].alias.should.eql('Fire Brigade')
-                res.body[0].should.have.property('agency')
-                res.body[0].agency.should.eql('FIRE')
-                res.body[0].should.have.property('icon')
-                res.body[0].icon.should.eql('fire')
-                res.body[0].should.have.property('color')
-                res.body[0].color.should.eql('red')
-                res.body[0].should.have.property('pluginconf')
-                res.body[0].should.have.property('ignore')
-                res.body[0].ignore.should.eql(0)
-                res.body.length.should.eql(1)
-                done();
-            });
-    });
-    it('should return all capcodes with specific agency when api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency/FIRE')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('array');
-                res.body[0].should.have.property('id')
-                res.body[0].id.should.eql(1)
-                res.body[0].should.have.property('address')
-                res.body[0].address.should.eql('1234567')
-                res.body[0].should.have.property('alias')
-                res.body[0].alias.should.eql('Fire Brigade')
-                res.body[0].should.have.property('agency')
-                res.body[0].agency.should.eql('FIRE')
-                res.body[0].should.have.property('icon')
-                res.body[0].icon.should.eql('fire')
-                res.body[0].should.have.property('color')
-                res.body[0].color.should.eql('red')
-                res.body[0].should.have.property('pluginconf')
-                res.body[0].should.have.property('ignore')
-                res.body[0].ignore.should.eql(0)
-                res.body.length.should.eql(1)
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return all capcodes with specific agency when api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency/FIRE')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('id');
+                                res.body[0].id.should.eql(1);
+                                res.body[0].should.have.property('address');
+                                res.body[0].address.should.eql('1234567');
+                                res.body[0].should.have.property('alias');
+                                res.body[0].alias.should.eql('Fire Brigade');
+                                res.body[0].should.have.property('agency');
+                                res.body[0].agency.should.eql('FIRE');
+                                res.body[0].should.have.property('icon');
+                                res.body[0].icon.should.eql('fire');
+                                res.body[0].should.have.property('color');
+                                res.body[0].color.should.eql('red');
+                                res.body[0].should.have.property('pluginconf');
+                                res.body[0].should.have.property('ignore');
+                                res.body[0].ignore.should.eql(0);
+                                res.body.length.should.eql(1);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodes/agency/FIRE')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency/FIRE')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodes/agency/FIRE')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .get('/api/capcodes/agency/FIRE')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency/FIRE')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodes/agency/FIRE')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
 describe('GET /api/capcodeCheck/:id', () => {
-    it('should return a capcode when address exists and logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return a capcode when address exists and logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodeCheck/1234568')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql(2);
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('1234568');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('Ambulance 1');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('AMBULANCE');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('ambulance');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('green');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodeCheck/1234568')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql(2)
-                res.body.should.have.property('address')
-                res.body.address.should.eql('1234568')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('Ambulance 1')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('AMBULANCE')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('ambulance')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('green')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return blank capcode when address doesnt exist and logged in as admin', done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should return blank capcode when address doesnt exist and logged in as admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .get('/api/capcodeCheck/7654321')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql('');
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('question');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('black');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodeCheck/7654321')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql('')
-                res.body.should.have.property('address')
-                res.body.address.should.eql('')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('question')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('black')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return a capcode when address exists and apikey provided', done => {
-        chai.request(server)
-            .get('/api/capcodeCheck/1234568')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql(2)
-                res.body.should.have.property('address')
-                res.body.address.should.eql('1234568')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('Ambulance 1')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('AMBULANCE')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('ambulance')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('green')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return blank capcode when address doesnt exist and apikey provided', done => {
-        chai.request(server)
-            .get('/api/capcodeCheck/7654321')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                res.status.should.eql(200);
-                res.type.should.eql('application/json');
-                res.body.should.be.a('object');
-                res.body.should.have.property('id')
-                res.body.id.should.eql('')
-                res.body.should.have.property('address')
-                res.body.address.should.eql('')
-                res.body.should.have.property('alias')
-                res.body.alias.should.eql('')
-                res.body.should.have.property('agency')
-                res.body.agency.should.eql('')
-                res.body.should.have.property('icon')
-                res.body.icon.should.eql('question')
-                res.body.should.have.property('color')
-                res.body.color.should.eql('black')
-                res.body.should.have.property('pluginconf')
-                res.body.should.have.property('ignore')
-                res.body.ignore.should.eql(0)
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return a capcode when address exists and apikey provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodeCheck/1234568')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql(2);
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('1234568');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('Ambulance 1');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('AMBULANCE');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('ambulance');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('green');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
         });
-        chai.request(server)
-            .get('/api/capcodeCheck/1234567')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .get('/api/capcodeCheck/1234567')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .get('/api/capcodeCheck/1234567')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return blank capcode when address doesnt exist and apikey provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodeCheck/7654321')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.have.property('id');
+                                res.body.id.should.eql('');
+                                res.body.should.have.property('address');
+                                res.body.address.should.eql('');
+                                res.body.should.have.property('alias');
+                                res.body.alias.should.eql('');
+                                res.body.should.have.property('agency');
+                                res.body.agency.should.eql('');
+                                res.body.should.have.property('icon');
+                                res.body.icon.should.eql('question');
+                                res.body.should.have.property('color');
+                                res.body.color.should.eql('black');
+                                res.body.should.have.property('pluginconf');
+                                res.body.should.have.property('ignore');
+                                res.body.ignore.should.eql(0);
+                                done();
+                        });
+        });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .get('/api/capcodeCheck/1234567')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .get('/api/capcodeCheck/1234567')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .get('/api/capcodeCheck/1234567')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
 describe('POST /api/capcodeRefresh', () => {
-    it('should perform a capcode refresh when admin' , done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should perform a capcode refresh when admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .post('/api/capcodeRefresh')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.body.should.have.property('status').eql('ok');
+                                res.type.should.eql('application/json');
+                                done();
+                        });
         });
-        chai.request(server)
-            .post('/api/capcodeRefresh')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.body.should.have.property('status').eql('ok')
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should perform a capcode refresh when apikey provided' , done => {
-        chai.request(server)
-            .post('/api/capcodeRefresh')
-            .set('apikey', 'reallylongkeythatneedstobechanged')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.body.should.have.property('status').eql('ok')
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should perform a capcode refresh when apikey provided', (done) => {
+                chai.request(server)
+                        .post('/api/capcodeRefresh')
+                        .set('apikey', 'reallylongkeythatneedstobechanged')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.body.should.have.property('status').eql('ok');
+                                res.type.should.eql('application/json');
+                                done();
+                        });
         });
-        chai.request(server)
-            .post('/api/capcodeRefresh')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .post('/api/capcodeRefresh')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .post('/api/capcodeRefresh')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .post('/api/capcodeRefresh')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .post('/api/capcodeRefresh')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .post('/api/capcodeRefresh')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
 describe('POST /api/capcodeExport', () => {
-    it('should perform a capcode export when admin' , done => {
-        passportStub.login({
-            username: 'adminactive',
-            password: 'changeme',
-            role: 'admin'
+        it('should perform a capcode export when admin', (done) => {
+                passportStub.login({
+                        username: 'adminactive',
+                        password: 'changeme',
+                        role: 'admin',
+                });
+                chai.request(server)
+                        .post('/api/capcodeExport')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.body.should.have.property('status').eql('ok');
+                                res.body.should.have.property('data');
+                                res.type.should.eql('application/json');
+                                done();
+                        });
         });
-        chai.request(server)
-            .post('/api/capcodeExport')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(200);
-                res.body.should.have.property('status').eql('ok')
-                res.body.should.have.property('data')
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not admin', done => {
-        passportStub.login({
-            username: 'useractive',
-            password: 'changeme',
-            role: 'user'
+        it('should return a 401 when not admin', (done) => {
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                        role: 'user',
+                });
+                chai.request(server)
+                        .post('/api/capcodeExport')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
         });
-        chai.request(server)
-            .post('/api/capcodeExport')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when not logged in', done => {
-        chai.request(server)
-            .post('/api/capcodeExport')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
-    it('should return a 401 when incorrect api key provided', done => {
-        chai.request(server)
-            .post('/api/capcodeExport')
-            .set('apikey', 'shortkeythatdoesntexist')
-            .end((err, res) => {
-                should.not.exist(err);
-                res.status.should.eql(401);
-                res.type.should.eql('application/json');
-                done();
-            });
-    });
+        it('should return a 401 when not logged in', (done) => {
+                chai.request(server)
+                        .post('/api/capcodeExport')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
+        it('should return a 401 when incorrect api key provided', (done) => {
+                chai.request(server)
+                        .post('/api/capcodeExport')
+                        .set('apikey', 'shortkeythatdoesntexist')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(401);
+                                res.type.should.eql('application/json');
+                                done();
+                        });
+        });
 });
 
-describe('POST /api/capcodeImport', () => {
-});
+describe('POST /api/capcodeImport', () => {});

--- a/server/test/routes.api.messages.id.test.js
+++ b/server/test/routes.api.messages.id.test.js
@@ -37,18 +37,18 @@ describe('GET /api/messages/id', () => {
                 nconf.set('messages:HideCapcode', true);
                 nconf.save();
                 chai.request(server)
-                        .get('/api/messages/5')
+                        .get('/api/messages/4')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.should.have.property('id').eql(5);
+                                res.body.should.have.property('id').eql(4);
                                 res.body.should.not.have.property('address');
                                 res.body.should.have
                                         .property('message')
-                                        .eql('This is a Test Message to Address 1234570');
-                                res.body.should.have.property('source').eql('Client 4');
+                                        .eql('This is a Test Message to Address 1234569');
+                                res.body.should.have.property('source').eql('Client 3');
                                 nconf.set('messages:HideCapcode', false);
                                 done();
                         });

--- a/server/test/routes.api.messages.test.js
+++ b/server/test/routes.api.messages.test.js
@@ -54,7 +54,7 @@ describe('POST /api/messages', () => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('text/html');
-                                res.text.should.be.eql('6');
+                                res.text.should.be.eql('7');
                                 done();
                         });
         });

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -63,7 +63,7 @@ describe('GET /api/messageSearch', () => {
         });
         it('should return result for existing alias', (done) => {
                 chai.request(server)
-                        .get('/api/messageSearch?alias=0')
+                        .get('/api/messageSearch?alias=1')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
@@ -92,6 +92,18 @@ describe('GET /api/messageSearch', () => {
                                         .property('message')
                                         .eql('This is a Test Message to non-stored Address 1234572');
                                 res.body.messages[0].should.have.property('source').eql('Client 4');
+                                done();
+                        });
+        });
+        it('should not return result for alias with no messages', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?alias=4')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                should.not.exist(res.body.messages[0]);
                                 done();
                         });
         });

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -32,7 +32,7 @@ beforeEach(() => db.migrate.rollback().then(() => db.migrate.latest().then(() =>
 afterEach(() => db.migrate.rollback().then(() => passportStub.logout()));
 
 describe('GET /api/messageSearch', () => {
-        it('should return resut for existing term', done => {
+        it('should return result for existing term', (done) => {
                 chai.request(server)
                         .get('/api/messageSearch?q=test')
                         .end((err, res) => {
@@ -49,9 +49,84 @@ describe('GET /api/messageSearch', () => {
                                 done();
                         });
         });
-        it('should not return resut for non-existing term', done => {
+        it('should not return result for non-existing term', (done) => {
                 chai.request(server)
                         .get('/api/messageSearch?q=thisisnotmessage')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                should.not.exist(res.body.messages[0]);
+                                done();
+                        });
+        });
+        it('should return result for existing alias', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?alias=0')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.messages[0].should.have.property('id').eql(0);
+                                res.body.messages[0].should.have.property('address').eql('1234567');
+                                res.body.messages[0].should.have
+                                        .property('message')
+                                        .eql('This is a Test Message to Address 1234567');
+                                res.body.messages[0].should.have.property('source').eql('Client 1');
+                                done();
+                        });
+        });
+        it('should return result for message missing alias', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?alias=-1')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.messages[0].should.have.property('id').eql(6);
+                                res.body.messages[0].should.have.property('address').eql('1234572');
+                                res.body.messages[0].should.have
+                                        .property('message')
+                                        .eql('This is a Test Message to non-stored Address 1234572');
+                                res.body.messages[0].should.have.property('source').eql('Client 4');
+                                done();
+                        });
+        });
+        it('should not return result for non-existing alias', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?alias=18')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                should.not.exist(res.body.messages[0]);
+                                done();
+                        });
+        });
+        it('should return result for existing address', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?address=1234569')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.messages[0].should.have.property('id').eql(4);
+                                res.body.messages[0].should.have.property('address').eql('1234569');
+                                res.body.messages[0].should.have
+                                        .property('message')
+                                        .eql('This is a Test Message to Address 1234569');
+                                res.body.messages[0].should.have.property('source').eql('Client 3');
+                                done();
+                        });
+        });
+        it('should not return result for non-existing address', (done) => {
+                chai.request(server)
+                        .get('/api/messageSearch?address=1234585')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -63,17 +63,17 @@ describe('GET /api/messageSearch', () => {
         });
         it('should return result for existing alias', (done) => {
                 chai.request(server)
-                        .get('/api/messageSearch?alias=1')
+                        .get('/api/messageSearch?alias=2')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.messages[0].should.have.property('id').eql(0);
-                                res.body.messages[0].should.have.property('address').eql('1234567');
+                                res.body.messages[0].should.have.property('id').eql(3);
+                                res.body.messages[0].should.have.property('address').eql('1234569');
                                 res.body.messages[0].should.have
                                         .property('message')
-                                        .eql('This is a Test Message to Address 1234567');
+                                        .eql('This is a Test Message to Address 1234569');
                                 res.body.messages[0].should.have.property('source').eql('Client 1');
                                 done();
                         });

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -63,18 +63,19 @@ describe('GET /api/messageSearch', () => {
         });
         it('should return result for existing alias', (done) => {
                 chai.request(server)
-                        .get('/api/messageSearch?alias=2')
+                        .get('/api/messageSearch?alias=1')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.messages[0].should.have.property('id').eql(3);
-                                res.body.messages[0].should.have.property('address').eql('1234569');
+                                res.body.messages[0].should.have.property('id').eql(1);
+                                res.body.messages[0].should.have.property('address').eql('1234567');
                                 res.body.messages[0].should.have
                                         .property('message')
-                                        .eql('This is a Test Message to Address 1234569');
-                                res.body.messages[0].should.have.property('source').eql('Client 1');
+                                        .eql('This is another Test Message to Address 1234567');
+                                res.body.messages[0].should.have.property('source').eql('Client 2');
+                                res.body.messages.length.should.eql(2);
                                 done();
                         });
         });
@@ -86,12 +87,11 @@ describe('GET /api/messageSearch', () => {
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.messages[0].should.have.property('id').eql(6);
                                 res.body.messages[0].should.have.property('address').eql('1234572');
                                 res.body.messages[0].should.have
                                         .property('message')
                                         .eql('This is a Test Message to non-stored Address 1234572');
-                                res.body.messages[0].should.have.property('source').eql('Client 4');
+                                res.body.messages[0].should.have.property('source').eql('Client 5');
                                 done();
                         });
         });

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -70,7 +70,7 @@ describe('GET /api/messageSearch', () => {
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
                                 res.body.messages.length.should.eq(2);
-                                res.body.messages[0].should.have.property('id').eql(1);
+                                res.body.messages[0].should.have.property('id').eql(2);
                                 res.body.messages[0].should.have.property('address').eql('1234567');
                                 res.body.messages[0].should.have
                                         .property('message')

--- a/server/test/routes.api.messagesearch.test.js
+++ b/server/test/routes.api.messagesearch.test.js
@@ -69,6 +69,7 @@ describe('GET /api/messageSearch', () => {
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
+                                res.body.messages.length.should.eq(2);
                                 res.body.messages[0].should.have.property('id').eql(1);
                                 res.body.messages[0].should.have.property('address').eql('1234567');
                                 res.body.messages[0].should.have

--- a/server/themes/default/public/templates/popover.html
+++ b/server/themes/default/public/templates/popover.html
@@ -12,6 +12,7 @@
     </div>
     <div ng-if="popoverEl == 'alias'">
         <a class="btn" ng-if="message.alias_id" href="/?alias={{message.alias_id}}">Filter</a>
+        <a class="btn" ng-if="!message.alias_id" href="/?alias=-1">Filter</a>
         <a class="btn" ng-if="message.alias_id && role == 'admin'" target="_blank" href="/admin/aliases/{{message.alias_id}}">Edit Alias</a>
         <a class="btn" ng-if="(!message.alias_id || message.wildcard) && role == 'admin'" target="_blank" href="/admin/aliases/new?address={{message.address}}">Create Alias</a>
     </div>


### PR DESCRIPTION
# Description

This feature offers the possibility to filter for those message, who don't have a matching alias associated in the messages table. The message view offers filtering on messages without alias and triggers a message search for `alias=-1`. 
The API does check requests for that particular ID and, if found, does not search for that id, but for `alias IS NULL`.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested on local testing instance
- [X] Added new mocha tests that did successfully run

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



