### PR TITLE
Bugfix: Add Dockerignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
 * Add MQTT Plugin #584 @ChoffaH
 * Hide Capcode in Small Screen mode Hide Capcode in Small Screen mode #583 @bullseye555
+* Add dockerignore file #595 @eopo
   
 
 # 0.3.13 - 2023-09-04

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+config/backup.json
+config/config.json
+node_modules/*
+package_lock.json
+.vscode


### PR DESCRIPTION
# Description

I included a docker ignore file to the server directory.
In the past, locally created configs would be copied into the docker container. The build process would fail during the copy default -> config step, because that file already existed.
Also, node_modules folder and package-lock are now excluded in order to not interfere with the build 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local build tries

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



