### PR TITLE
Feature: make cleaner pluginconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
 * Add MQTT Plugin #584 @ChoffaH
 * Hide Capcode in Small Screen mode Hide Capcode in Small Screen mode #583 @bullseye555
+* Clean up Plugin configuration for aliasses #596 @eopo
   
 
 # 0.3.13 - 2023-09-04

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -5,6 +5,7 @@ var basicAuth = require('express-basic-auth');
 var bcrypt = require('bcryptjs');
 var util = require('util');
 var _ = require('underscore');
+const {pickBy} = require('lodash');
 var pluginHandler = require('../plugins/pluginHandler');
 var logger = require('../log');
 var db = require('../knex/knex.js');
@@ -1499,7 +1500,7 @@ function parseJSON(json) {
  * @returns A sanitized version of the plugin configuration object holding only plugins with values set
  */
 function vaccumPluginConf(pconf) {
-  const cleaned = _.pickBy(pconf, p => {
+  const cleaned = pickBy(pconf, p => {
       return Object.keys(p).length > 0
   })
   return cleaned;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1493,6 +1493,11 @@ function parseJSON(json) {
   return parsed;
 }
 
+/**
+ * Removes all empty objects from a plugin configuration
+ * @param {Object} pconf An object containing a key for each Plugin, holding it's configuration
+ * @returns A sanitized version of the plugin configuration object holding only plugins with values set
+ */
 function vaccumPluginConf(pconf) {
   const cleaned = _.pickBy(pconf, p => {
       return Object.keys(p).length > 0

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -752,31 +752,31 @@ router.route('/capcodes')
       var color = req.body.color || 'black';
       var icon = req.body.icon || 'question';
       var ignore = req.body.ignore || 0;
-      var pluginconf = JSON.stringify(req.body.pluginconf) || "{}";
+      var pluginconf = JSON.stringify(vaccumPluginConf(req.body.pluginconf)) || "{}";
       db.from('capcodes')
         .where('id', '=', id)
         .modify(function (queryBuilder) {
           if (id == null) {
             queryBuilder.insert({
-              id: id,
-              address: address,
-              alias: alias,
-              agency: agency,
-              color: color,
-              icon: icon,
-              ignore: ignore,
-              pluginconf: pluginconf
+              id,
+              address,
+              alias,
+              agency,
+              color,
+              icon,
+              ignore,
+              pluginconf
             })
           } else {
             queryBuilder.update({
-              id: id,
-              address: address,
-              alias: alias,
-              agency: agency,
-              color: color,
-              icon: icon,
-              ignore: ignore,
-              pluginconf: pluginconf
+              id,
+              address,
+              alias,
+              agency,
+              color,
+              icon,
+              ignore,
+              pluginconf
             })
           }
         })
@@ -900,7 +900,7 @@ router.route('/capcodes/:id')
         var color = req.body.color || 'black';
         var icon = req.body.icon || 'question';
         var ignore = req.body.ignore || 0;
-        var pluginconf = JSON.stringify(req.body.pluginconf) || "{}";
+        var pluginconf = JSON.stringify(vaccumPluginConf(req.body.pluginconf)) || "{}";
         var updateAlias = req.body.updateAlias || 0;
 
         console.time('insert');
@@ -910,25 +910,25 @@ router.route('/capcodes/:id')
           .modify(function (queryBuilder) {
             if (id == null) {
               queryBuilder.insert({
-                id: id,
-                address: address,
-                alias: alias,
-                agency: agency,
-                color: color,
-                icon: icon,
-                ignore: ignore,
-                pluginconf: pluginconf
+                id,
+                address,
+                alias,
+                agency,
+                color,
+                icon,
+                ignore,
+                pluginconf
               })
             } else {
               queryBuilder.update({
-                id: id,
-                address: address,
-                alias: alias,
-                agency: agency,
-                color: color,
-                icon: icon,
-                ignore: ignore,
-                pluginconf: pluginconf
+                id,
+                address,
+                alias,
+                agency,
+                color,
+                icon,
+                ignore,
+                pluginconf
               })
             }
           })
@@ -1134,7 +1134,7 @@ router.route('/capcodeImport')
             var color = capcode.color || 'black';
             var icon = capcode.icon || 'question';
             var ignore = capcode.ignore || 0;
-            var pluginconf = JSON.stringify(capcode.pluginconf) || "{}";
+            var pluginconf = JSON.stringify(vaccumPluginConf(capcode.pluginconf)) || "{}";
             await db('capcodes')
               .returning('id')
               .where('address', '=', address)
@@ -1145,13 +1145,13 @@ router.route('/capcodeImport')
                   return db('capcodes')
                     .where('id', '=', rows.id)
                     .update({
-                      address: address,
-                      alias: alias,
-                      agency: agency,
-                      color: color,
-                      icon: icon,
-                      ignore: ignore,
-                      pluginconf: pluginconf
+                      address,
+                      alias,
+                      agency,
+                      color,
+                      icon,
+                      ignore,
+                      pluginconf
                     })
                     .then((result) => {
                       importresults.push({
@@ -1164,20 +1164,20 @@ router.route('/capcodeImport')
                       importresults.push({
                         address: address,
                         alias: alias,
-                        result: 'failed' + err
+                        result: 'failed ' + err
                       })
                     })
                 } else {
                   //Create new alias if one didn't get returned.
                   return db('capcodes').insert({
                     id: null,
-                    address: address,
-                    alias: alias,
-                    agency: agency,
-                    color: color,
-                    icon: icon,
-                    ignore: ignore,
-                    pluginconf: pluginconf
+                    address,
+                    alias,
+                    agency,
+                    color,
+                    icon,
+                    ignore,
+                    pluginconf
                   })
                     .then((result) => {
                       importresults.push({
@@ -1491,4 +1491,11 @@ function parseJSON(json) {
     // ignore errors
   }
   return parsed;
+}
+
+function vaccumPluginConf(pconf) {
+  const cleaned = _.pickBy(pconf, p => {
+      return Object.keys(p).length > 0
+  })
+  return cleaned;
 }


### PR DESCRIPTION
# Description

Remove empty objects in pluginconf object of an alias.
This is done for two reasons:
- Easier overview when reviewing aliases outside of pagermon, e.g. as CSV export
- Smaller runtime, because server doesn't have to loop over all plugins, even when not 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Run mocha tests
- [X] Local test system
- [X] Implemented same change in local production environment a while ago

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



