### PR TITLE
Fix: View alias filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Revert to FontAwesome 4 to fix performance issues. #574 @Danrw
 * Add MQTT Plugin #584 @ChoffaH
 * Hide Capcode in Small Screen mode Hide Capcode in Small Screen mode #583 @bullseye555
+* Show filter criteria in message view #598 @eopo
   
 
 # 0.3.13 - 2023-09-04

--- a/server/themes/default/views/index.ejs
+++ b/server/themes/default/views/index.ejs
@@ -97,7 +97,7 @@
             <th class="noMobile noSmall"></th>
             <th style="text-align: center;">Message
               <span ng-if="filter || hasQuery" class="pull-left" style="vertical-align: middle; padding-right: 10px;">
-                  <strong>Filter:</strong> <a ng-href="/" style="margin-bottom: 3px;" class="btn btn-primary btn-xs">{{filter || origQuery}} <i class="fa fa-fw fa-times"></i></a>
+                  <strong>Filter:</strong> <a ng-href="/" style="margin-bottom: 3px;" class="btn btn-primary btn-xs">{{ filterString || origQuery}} <i class="fa fa-fw fa-times"></i></a>
               </span></th>
           </tr>
         </thead>
@@ -442,14 +442,22 @@
                 }
 
                 if ($routeParams.agency || $routeParams.address || $routeParams.alias) {
+                  const activeFilters = []
                   $scope.filter = $routeParams.agency || $routeParams.address || $routeParams.alias;
                   $scope.hasQuery = true;
-                  if ($routeParams.agency)
+                  if ($routeParams.agency){
+                    activeFilters.push(`Agency: ${$routeParams.agency}`)
                     queryObj.agency = $routeParams.agency;
-                  if ($routeParams.address)
+                  }
+                  if ($routeParams.address){
+                    activeFilters.push(`Address: ${$routeParams.address}`)
                     queryObj.address = $routeParams.address;
-                  if ($routeParams.alias)
+                  }
+                  if ($routeParams.alias){
+                    activeFilters.push(`Alias: ${$routeParams.alias}`)
                     queryObj.alias = $routeParams.alias;
+                  }
+                  $scope.filterString = activeFilters.join(' & ');
                 }
 
                 if (page) {


### PR DESCRIPTION
# Description
As of now, the message view isn't really precise when a filter is applied.
It does show, what value we're looking for, but not, what kind of value it is.
This PR implements that the filter value is preceded by the field name.
I'd really love to add the alias name, when we're searching for an alias, but Angular won't let me do it (Just kidding, I just don't know how).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Tests on local system
- [X] Passes mocha tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



