### PR TITLE
Feature: Hide messages with certain alias to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 * Clean up Plugin configuration for aliasses #596 @eopo
 * Improve everything around sockets #597 @eopo
 * Show filter criteria in message view #598 @eopo
+* Add a new feature to hide aliasses from public #599 @eopo
 
-  
 # 0.3.13 - 2023-09-04
 * Add Config option to fix FA icon's no longer loading. @marshyonline
 

--- a/server/knex/migrations/20240415185712_create_capcode_onlyShowLoggedIn.js
+++ b/server/knex/migrations/20240415185712_create_capcode_onlyShowLoggedIn.js
@@ -1,0 +1,72 @@
+const nconf = require('nconf');
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ * */
+
+/**
+ * SQLITE does not allow tables to be renamed, if a trigger has a foreign key relation to them.
+ * Therefore, we have to temporarily delete the triggers and re-install them after doing the migration.
+ */
+
+const up = async function(knex) {
+        const isSqLite = nconf.get('database:type') === 'sqlite3';
+        let triggers;
+        if (isSqLite) {
+                triggers = await knex
+                        .from('sqlite_master')
+                        .select(['name', 'sql'])
+                        .where('type', 'trigger');
+
+                const promises = triggers.map(trigger => knex.raw(`DROP TRIGGER ${trigger.name}`));
+
+                await Promise.all(promises);
+        }
+        if (!(await knex.schema.hasTable('capcodes')))
+                return Promise((resolve, reject) => {
+                        reject('Capcode table is missing!');
+                });
+
+        await knex.schema.alterTable('capcodes', table => {
+                table.boolean('onlyShowLoggedIn').defaultTo(false);
+        });
+
+        await knex('capcodes').update({ onlyShowLoggedIn: false });
+
+        if (isSqLite) {
+                const promises = triggers.map(trigger => knex.raw(trigger.sql));
+                await Promise.all(promises);
+        }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function(knex) {
+        const isSqLite = nconf.get('database:type') === 'sqlite3';
+        let triggers;
+        if (isSqLite) {
+                triggers = await knex
+                        .from('sqlite_master')
+                        .select(['name', 'sql'])
+                        .where('type', 'trigger');
+
+                const promises = triggers.map(trigger => knex.raw(`DROP TRIGGER ${trigger.name}`));
+
+                await Promise.all(promises);
+        }
+
+        await knex.schema.alterTable('capcodes', table => {
+                table.dropColumn('onlyShowLoggedIn');
+        });
+
+        if (isSqLite) {
+                const promises = triggers.map(trigger => knex.raw(trigger.sql));
+                await Promise.all(promises);
+        }
+};
+
+module.exports.up = up;
+module.exports.down = down;

--- a/server/knex/seeds/test_data.js
+++ b/server/knex/seeds/test_data.js
@@ -7,35 +7,48 @@ exports.seed = function(db, Promise) {
         address: '1234567',
         message: 'This is a Test Message to Address 1234567',
         source: 'Client 1',
-        timestamp: '1529487722'
+        timestamp: '1529487722',
+        alias_id: 1,
       });
     }).then(function () {
       return db('messages').insert({
         address: '1234567',
         message: 'This is another Test Message to Address 1234567',
         source: 'Client 2',
-        timestamp: '1529488007'
+        timestamp: '1529488007',
+        alias_id: 1,
       });
     }).then(function () {
       return db('messages').insert({
         address: '1234568',
         message: 'This is a Test Message to Address 1234568',
         source: 'Client 1',
-        timestamp: '1529489509'
+        timestamp: '1529489509',
+        alias_id: 2,
       });
     }).then(function () {
       return db('messages').insert({
         address: '1234569',
         message: 'This is a Test Message to Address 1234569',
         source: 'Client 3',
-        timestamp: '1529495672'
+        timestamp: '1529495672',
+        alias_id: 3,
       });
     }).then(function () {
       return db('messages').insert({
         address: '1234570',
         message: 'This is a Test Message to Address 1234570',
         source: 'Client 4',
-        timestamp: '1529494321'
+        timestamp: '1529494321',
+        alias_id: 4,
+      });
+    }).then(function () {
+      return db('messages').insert({
+        address: '1234571',
+        message: 'This is a Test Message to Address 1234571, that should be hidden to unauthorized users',
+        source: 'Client 4',
+        timestamp: '1529494321',
+        alias_id: 5,
       });
     }).then(function () {
       return db('capcodes').del()
@@ -47,6 +60,7 @@ exports.seed = function(db, Promise) {
         icon: 'fire',
         color: 'red',
         ignore: '0',
+        onlyShowLoggedIn: false,
       });
     }).then(function () {
       return db('capcodes').insert({
@@ -56,6 +70,7 @@ exports.seed = function(db, Promise) {
         icon: 'ambulance',
         color: 'green',
         ignore: '0',
+        onlyShowLoggedIn: false,
       });
     }).then(function () {
       return db('capcodes').insert({
@@ -65,6 +80,7 @@ exports.seed = function(db, Promise) {
         icon: 'gavel',
         color: 'blue',
         ignore: '0',
+        onlyShowLoggedIn: false,
       });
     }).then(function () {
       return db('capcodes').insert({
@@ -74,6 +90,17 @@ exports.seed = function(db, Promise) {
         icon: '',
         color: '',
         ignore: '1',
+        onlyShowLoggedIn: false,
+      });
+    }).then(function () {
+      return db('capcodes').insert({
+        address: '1234571',
+        alias: 'Hidden Capcode',
+        agency: 'HIDE',
+        icon: '',
+        color: '',
+        ignore: '0',
+        onlyShowLoggedIn: true,
       });
     }).then(function () {
       return db('users').del()

--- a/server/test/routes.api.capcodes.test.js
+++ b/server/test/routes.api.capcodes.test.js
@@ -49,7 +49,7 @@ describe('GET /api/capcodes', () => {
                 res.body[0].should.have.property('color')
                 res.body[0].should.have.property('pluginconf')
                 res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(4)
+                res.body.length.should.eql(5)
                 done();
             });
     });
@@ -70,7 +70,7 @@ describe('GET /api/capcodes', () => {
                 res.body[0].should.have.property('color')
                 res.body[0].should.have.property('pluginconf')
                 res.body[0].should.have.property('ignore')
-                res.body.length.should.eql(4)
+                res.body.length.should.eql(5)
                 done();
             });
     });
@@ -347,7 +347,7 @@ describe('GET /api/capcodes/agency', () => {
                 res.type.should.eql('application/json');
                 res.body.should.be.a('array');
                 res.body[0].should.have.property('agency')
-                res.body.length.should.eql(4)
+                res.body.length.should.eql(5)
                 done();
             });
     });
@@ -361,7 +361,7 @@ describe('GET /api/capcodes/agency', () => {
                 res.type.should.eql('application/json');
                 res.body.should.be.a('array');
                 res.body[0].should.have.property('agency')
-                res.body.length.should.eql(4)
+                res.body.length.should.eql(5)
                 done();
             });
     });

--- a/server/test/routes.api.messages.id.test.js
+++ b/server/test/routes.api.messages.id.test.js
@@ -37,18 +37,18 @@ describe('GET /api/messages/id', () => {
                 nconf.set('messages:HideCapcode', true);
                 nconf.save();
                 chai.request(server)
-                        .get('/api/messages/5')
+                        .get('/api/messages/4')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('object');
-                                res.body.should.have.property('id').eql(5);
+                                res.body.should.have.property('id').eql(4);
                                 res.body.should.not.have.property('address');
                                 res.body.should.have
                                         .property('message')
-                                        .eql('This is a Test Message to Address 1234570');
-                                res.body.should.have.property('source').eql('Client 4');
+                                        .eql('This is a Test Message to Address 1234569');
+                                res.body.should.have.property('source').eql('Client 3');
                                 nconf.set('messages:HideCapcode', false);
                                 done();
                         });
@@ -61,17 +61,55 @@ describe('GET /api/messages/id', () => {
                         password: 'changeme',
                 });
                 chai.request(server)
-                        .get('/api/messages/5')
+                        .get('/api/messages/4')
                         .end((err, res) => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('application/json');
                                 res.body.should.be.a('array');
-                                res.body[0].should.have.property('id').eql(5);
-                                res.body[0].should.have.property('address').eql('1234570');
+                                res.body[0].should.have.property('id').eql(4);
+                                res.body[0].should.have.property('address').eql('1234569');
                                 res.body[0].should.have
                                         .property('message')
-                                        .eql('This is a Test Message to Address 1234570');
+                                        .eql('This is a Test Message to Address 1234569');
+                                res.body[0].should.have.property('source').eql('Client 3');
+                                nconf.set('messages:HideCapcode', false);
+                                done();
+                        });
+        });
+        it('should not return message for onlyShowLoggedIn alias if not logged in ', done => {
+                chai.request(server)
+                        .get('/api/messages/6')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('object');
+                                res.body.should.eql({});
+                                done();
+                        });
+        });
+        it('should return message for onlyShowLoggedIn alias if logged in ', done => {
+                nconf.set('messages:HideCapcode', true);
+                nconf.save();
+                passportStub.login({
+                        username: 'useractive',
+                        password: 'changeme',
+                });
+                chai.request(server)
+                        .get('/api/messages/6')
+                        .end((err, res) => {
+                                should.not.exist(err);
+                                res.status.should.eql(200);
+                                res.type.should.eql('application/json');
+                                res.body.should.be.a('array');
+                                res.body[0].should.have.property('id').eql(6);
+                                res.body[0].should.have.property('address').eql('1234571');
+                                res.body[0].should.have
+                                        .property('message')
+                                        .eql(
+                                                'This is a Test Message to Address 1234571, that should be hidden to unauthorized users'
+                                        );
                                 res.body[0].should.have.property('source').eql('Client 4');
                                 nconf.set('messages:HideCapcode', false);
                                 done();

--- a/server/test/routes.api.messages.test.js
+++ b/server/test/routes.api.messages.test.js
@@ -54,7 +54,7 @@ describe('POST /api/messages', () => {
                                 should.not.exist(err);
                                 res.status.should.eql(200);
                                 res.type.should.eql('text/html');
-                                res.text.should.be.eql('6');
+                                res.text.should.be.eql('7');
                                 done();
                         });
         });

--- a/server/themes/default/public/templates/admin/aliasDetails.html
+++ b/server/themes/default/public/templates/admin/aliasDetails.html
@@ -162,6 +162,18 @@
               </div>
               </div>
             </div>
+            <div class="form-group" ng-class="{'has-warning':alias.ignore == 1}">
+              <label for="alias.onlyShowLoggedIn" class="col-xs-4 col-sm-3 control-label">Hide Alias</label>
+              <div class="col-xs-8 col-sm-9">
+              <div class="checkbox">
+                <label>
+                <input type="checkbox" name="alias.onlyShowLoggedIn" id="aliasHide" ng-model="alias.onlyShowLoggedIn" ng-true-value="1" ng-false-value="0">
+                Show only for logged-in users
+                </label>
+                <span id="helpBlock" class="help-block">Messages for that alias will only be shown to users that are logged in and will be hidden for everyone else.</span>
+              </div>
+              </div>
+            </div>
 
 
             <h4>Plugins</h4>


### PR DESCRIPTION
# Description
Aliases now have a checkbox, if their messages should only be shown to logged-in users.
Adds mocha tests for that
Also fixes a bug with others tests.

Fixes #576

## Type of change
- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test on local testing instance
- [X] New Mocha tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated changelog.md with changes made



