### PR TITLE
Add 'Alias: None' to filter view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Clean up Plugin configuration for aliasses #596 @eopo
 * Improve everything around sockets #597 @eopo
 * Show filter criteria in message view #598 @eopo
+* introduces showing 'Alias: None' when searching for messages without alias. #601 @eopo
 
   
 # 0.3.13 - 2023-09-04

--- a/server/themes/default/views/index.ejs
+++ b/server/themes/default/views/index.ejs
@@ -381,7 +381,10 @@
                     queryObj.address = $routeParams.address;
                   }
                   if ($routeParams.alias){
-                    activeFilters.push(`Alias: ${$routeParams.alias}`)
+                    if ($routeParams.alias === '-1')
+                      activeFilters.push(`Alias: None`)
+                    else 
+                      activeFilters.push(`Alias: ${$routeParams.alias}`)
                     queryObj.alias = $routeParams.alias;
                   }
                   $scope.filterString = activeFilters.join(' & ');


### PR DESCRIPTION
# Description
While #594 introduced searching for messages, that have no alias, #598 introduced showing, which searches are active. 
These two were not adapted to each other.
This pr now introduces showing 'Alias: None' when searching for messages without alias.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?
- [X] Passes mocha tests
- [X] Tested on local instance

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated changelog.md with changes made



